### PR TITLE
Address SpotBugs issues 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,11 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-annotations</artifactId>
+          <version>4.8.3</version>
+      </dependency>
   </dependencies>
 
   <build>
@@ -222,6 +227,28 @@
             <goals>
               <goal>integration-test</goal>
               <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.test.MainClassName</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase> <!-- packaging phase -->
+            <goals>
+              <goal>single</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -161,13 +161,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <version>${spotbugs.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
       <version>${prometheus.version}</version>

--- a/src/main/java/io/strimzi/kafka/metrics/KafkaMetricsCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/KafkaMetricsCollector.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.kafka.metrics;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.prometheus.client.Collector;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -27,8 +26,7 @@ public class KafkaMetricsCollector extends Collector {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaMetricsCollector.class.getName());
 
     private final Map<MetricName, KafkaMetric> metrics;
-    private final PrometheusMetricsReporterConfig config;
-    @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // Should be investigated as part of https://github.com/strimzi/metrics-reporter/issues/12
+    private PrometheusMetricsReporterConfig config;
     private String prefix;
 
     /**
@@ -39,6 +37,7 @@ public class KafkaMetricsCollector extends Collector {
     public KafkaMetricsCollector(PrometheusMetricsReporterConfig config) {
         this.config = config;
         this.metrics = new ConcurrentHashMap<>();
+        this.prefix = config.getMetricNamePrefix();
     }
 
     /**
@@ -48,6 +47,16 @@ public class KafkaMetricsCollector extends Collector {
      */
     public void setPrefix(String prefix) {
         this.prefix = prefix;
+    }
+
+    /**
+     * Configure the KafkaMetricsCollector with the provided configuration.
+     *
+     * @param config The PrometheusMetricsReporterConfig object containing the configuration.
+     */
+    public void configure(PrometheusMetricsReporterConfig config) {
+        this.config = config;
+        this.prefix = config.getMetricNamePrefix();
     }
 
     @Override

--- a/src/main/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporter.java
+++ b/src/main/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporter.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.kafka.metrics;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.HTTPServer;
 import io.prometheus.client.hotspot.DefaultExports;
@@ -29,16 +28,13 @@ import java.util.Set;
 public class KafkaPrometheusMetricsReporter implements MetricsReporter {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaPrometheusMetricsReporter.class.getName());
-
-    @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // Should be investigated as part of https://github.com/strimzi/metrics-reporter/issues/12
-    private KafkaMetricsCollector kafkaMetricsCollector;
-    @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // Should be investigated as part of https://github.com/strimzi/metrics-reporter/issues/12
-    private Optional<HTTPServer> httpServer;
+    private KafkaMetricsCollector kafkaMetricsCollector = new KafkaMetricsCollector(new PrometheusMetricsReporterConfig(Collections.emptyMap()));
+    private Optional<HTTPServer> httpServer = Optional.empty();
 
     @Override
     public void configure(Map<String, ?> map) {
         PrometheusMetricsReporterConfig config = new PrometheusMetricsReporterConfig(map);
-        kafkaMetricsCollector = new KafkaMetricsCollector(config);
+        kafkaMetricsCollector.configure(config);
         // Add JVM metrics
         DefaultExports.initialize();
         httpServer = config.startHttpServer();

--- a/src/main/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporter.java
+++ b/src/main/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporter.java
@@ -28,16 +28,15 @@ import java.util.Set;
 public class KafkaPrometheusMetricsReporter implements MetricsReporter {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaPrometheusMetricsReporter.class.getName());
-    private KafkaMetricsCollector kafkaMetricsCollector = new KafkaMetricsCollector(new PrometheusMetricsReporterConfig(Collections.emptyMap()));
+    private KafkaMetricsCollector kafkaMetricsCollector = new KafkaMetricsCollector();
     private Optional<HTTPServer> httpServer = Optional.empty();
 
     @Override
     public void configure(Map<String, ?> map) {
-        PrometheusMetricsReporterConfig config = new PrometheusMetricsReporterConfig(map);
-        kafkaMetricsCollector.configure(config);
+        kafkaMetricsCollector.configure(map);
         // Add JVM metrics
         DefaultExports.initialize();
-        httpServer = config.startHttpServer();
+        httpServer = kafkaMetricsCollector.config().startHttpServer();
     }
 
     @Override

--- a/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
+++ b/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
@@ -26,7 +26,18 @@ import java.util.regex.Pattern;
 public class PrometheusMetricsReporterConfig extends AbstractConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(PrometheusMetricsReporterConfig.class.getName());
+
     private static final String CONFIG_PREFIX = "prometheus.metrics.reporter.";
+    /**
+     * Configuration key for the metric name prefix.
+     */
+    public static final String METRIC_NAME_PREFIX_CONFIG = CONFIG_PREFIX + "metric.prefix";
+
+    /**
+     * Default value for the metric name prefix configuration.
+     */
+    public static final String METRIC_NAME_PREFIX_DEFAULT = "";
+    private static final String METRIC_NAME_PREFIX_DOC = "The prefix to be used for metric names.";
 
     /**
      * Configuration key for the listener to expose the metrics.
@@ -64,11 +75,15 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(LISTENER_CONFIG, ConfigDef.Type.STRING, LISTENER_CONFIG_DEFAULT, new ListenerValidator(), ConfigDef.Importance.HIGH, LISTENER_CONFIG_DOC)
             .define(ALLOWLIST_CONFIG, ConfigDef.Type.LIST, ALLOWLIST_CONFIG_DEFAULT, ConfigDef.Importance.HIGH, ALLOWLIST_CONFIG_DOC)
-            .define(LISTENER_ENABLE_CONFIG, ConfigDef.Type.BOOLEAN, LISTENER_ENABLE_CONFIG_DEFAULT, ConfigDef.Importance.HIGH, LISTENER_ENABLE_CONFIG_DOC);
+            .define(LISTENER_ENABLE_CONFIG, ConfigDef.Type.BOOLEAN, LISTENER_ENABLE_CONFIG_DEFAULT, ConfigDef.Importance.HIGH, LISTENER_ENABLE_CONFIG_DOC)
+            .define(METRIC_NAME_PREFIX_CONFIG, ConfigDef.Type.STRING, METRIC_NAME_PREFIX_DEFAULT, ConfigDef.Importance.HIGH, METRIC_NAME_PREFIX_DOC);
+
 
     private final Listener listener;
     private final boolean listenerEnabled;
     private final Pattern allowlist;
+    private final String metricNamePrefix;
+
 
     /**
      * Constructor.
@@ -80,6 +95,16 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
         this.listener = Listener.parseListener(getString(LISTENER_CONFIG));
         this.allowlist = compileAllowlist(getList(ALLOWLIST_CONFIG));
         this.listenerEnabled = getBoolean(LISTENER_ENABLE_CONFIG);
+        this.metricNamePrefix = getString(METRIC_NAME_PREFIX_CONFIG);
+    }
+
+    /**
+     * Retrieves the prefix used for metric names.
+     *
+     * @return The prefix used for metric names.
+     */
+    public String getMetricNamePrefix() {
+        return metricNamePrefix;
     }
 
     /**
@@ -121,6 +146,7 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
                 ", listener=" + listener +
                 ", listenerEnabled=" + listenerEnabled +
                 ", allowlist=" + allowlist +
+                ", metricNamePrefix=" + metricNamePrefix +
                 '}';
     }
 

--- a/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
+++ b/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
@@ -28,16 +28,6 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
     private static final Logger LOG = LoggerFactory.getLogger(PrometheusMetricsReporterConfig.class.getName());
 
     private static final String CONFIG_PREFIX = "prometheus.metrics.reporter.";
-    /**
-     * Configuration key for the metric name prefix.
-     */
-    public static final String METRIC_NAME_PREFIX_CONFIG = CONFIG_PREFIX + "metric.prefix";
-
-    /**
-     * Default value for the metric name prefix configuration.
-     */
-    public static final String METRIC_NAME_PREFIX_DEFAULT = "";
-    private static final String METRIC_NAME_PREFIX_DOC = "The prefix to be used for metric names.";
 
     /**
      * Configuration key for the listener to expose the metrics.
@@ -75,15 +65,11 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(LISTENER_CONFIG, ConfigDef.Type.STRING, LISTENER_CONFIG_DEFAULT, new ListenerValidator(), ConfigDef.Importance.HIGH, LISTENER_CONFIG_DOC)
             .define(ALLOWLIST_CONFIG, ConfigDef.Type.LIST, ALLOWLIST_CONFIG_DEFAULT, ConfigDef.Importance.HIGH, ALLOWLIST_CONFIG_DOC)
-            .define(LISTENER_ENABLE_CONFIG, ConfigDef.Type.BOOLEAN, LISTENER_ENABLE_CONFIG_DEFAULT, ConfigDef.Importance.HIGH, LISTENER_ENABLE_CONFIG_DOC)
-            .define(METRIC_NAME_PREFIX_CONFIG, ConfigDef.Type.STRING, METRIC_NAME_PREFIX_DEFAULT, ConfigDef.Importance.HIGH, METRIC_NAME_PREFIX_DOC);
-
+            .define(LISTENER_ENABLE_CONFIG, ConfigDef.Type.BOOLEAN, LISTENER_ENABLE_CONFIG_DEFAULT, ConfigDef.Importance.HIGH, LISTENER_ENABLE_CONFIG_DOC);
 
     private final Listener listener;
     private final boolean listenerEnabled;
     private final Pattern allowlist;
-    private final String metricNamePrefix;
-
 
     /**
      * Constructor.
@@ -95,16 +81,6 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
         this.listener = Listener.parseListener(getString(LISTENER_CONFIG));
         this.allowlist = compileAllowlist(getList(ALLOWLIST_CONFIG));
         this.listenerEnabled = getBoolean(LISTENER_ENABLE_CONFIG);
-        this.metricNamePrefix = getString(METRIC_NAME_PREFIX_CONFIG);
-    }
-
-    /**
-     * Retrieves the prefix used for metric names.
-     *
-     * @return The prefix used for metric names.
-     */
-    public String getMetricNamePrefix() {
-        return metricNamePrefix;
     }
 
     /**
@@ -146,7 +122,6 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
                 ", listener=" + listener +
                 ", listenerEnabled=" + listenerEnabled +
                 ", allowlist=" + allowlist +
-                ", metricNamePrefix=" + metricNamePrefix +
                 '}';
     }
 


### PR DESCRIPTION
When running Spotbugs against the project, it was throwing the following errors:

```[ERROR] Low: KafkaMetricsCollector.prefix not initialized in constructor and dereferenced in io.strimzi.kafka.metrics.KafkaMetricsCollector.metricName(MetricName) [io.strimzi.kafka.metrics.KafkaMetricsCollector] At KafkaMetricsCollector.java:[line 76] UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR
[ERROR] Low: KafkaPrometheusMetricsReporter.httpServer not initialized in constructor and dereferenced in io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter.getPort() [io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter] At KafkaPrometheusMetricsReporter.java:[line 90] UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR
[ERROR] Low: KafkaPrometheusMetricsReporter.kafkaMetricsCollector not initialized in constructor and dereferenced in io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter.contextChange(MetricsContext) [io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter] At KafkaPrometheusMetricsReporter.java:[line 86] UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR
[ERROR] Low: KafkaPrometheusMetricsReporter.kafkaMetricsCollector not initialized in constructor and dereferenced in io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter.metricChange(KafkaMetric) [io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter] At KafkaPrometheusMetricsReporter.java:[line 55] UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR
[ERROR] Low: KafkaPrometheusMetricsReporter.kafkaMetricsCollector not initialized in constructor and dereferenced in io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter.metricRemoval(KafkaMetric) [io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter] At KafkaPrometheusMetricsReporter.java:[line 61] UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR```

This PR will try to fix this issue by making KafkaMetricsCollector configurable and adding to necessary constructors items. 

