### PR TITLE
Handle non-numeric metric values

### DIFF
--- a/src/main/java/io/strimzi/kafka/metrics/KafkaMetricsCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/KafkaMetricsCollector.java
@@ -111,7 +111,7 @@ public class KafkaMetricsCollector extends Collector {
 
     static MetricFamilySamples convert(String name, String help, KafkaMetric metric, Map<String, String> labels) {
         Object valueObj = metric.metricValue();
-        final double value;
+        double value;
         Map<String, String> sanitizedLabels = labels.entrySet().stream()
                 .collect(Collectors.toMap(
                         e -> Collector.sanitizeMetricName(e.getKey()),

--- a/src/main/java/io/strimzi/kafka/metrics/MetricFamilySamplesBuilder.java
+++ b/src/main/java/io/strimzi/kafka/metrics/MetricFamilySamplesBuilder.java
@@ -64,6 +64,15 @@ public class MetricFamilySamplesBuilder {
         return new Collector.MetricFamilySamples(samples.get(0).name, type, help, samples);
     }
 
+    /**
+     * Sanitizes the given map of labels by replacing any characters in the label keys
+     * that are not allowed in Prometheus metric names with an underscore ('_').
+     * If there are duplicate keys after sanitization, a warning is logged, and the first value is retained.
+     *
+     * @param labels The map of labels to be sanitized. The keys of this map are label names,
+     *               and the values are label values.
+     * @return A new map with sanitized label names and the same label values.
+     */
     public static Map<String, String> sanitizeLabels(Map<String, String> labels) {
         return labels.entrySet().stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/io/strimzi/kafka/metrics/MetricFamilySamplesBuilder.java
+++ b/src/main/java/io/strimzi/kafka/metrics/MetricFamilySamplesBuilder.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
  */
 public class MetricFamilySamplesBuilder {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaMetricsCollector.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(MetricFamilySamplesBuilder.class.getName());
     private final Collector.Type type;
     private final String help;
     private final List<Collector.MetricFamilySamples.Sample> samples;

--- a/src/main/java/io/strimzi/kafka/metrics/MetricFamilySamplesBuilder.java
+++ b/src/main/java/io/strimzi/kafka/metrics/MetricFamilySamplesBuilder.java
@@ -6,18 +6,23 @@ package io.strimzi.kafka.metrics;
 
 import com.yammer.metrics.stats.Snapshot;
 import io.prometheus.client.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Helper class to convert Kafka metrics into the Prometheus format.
  */
 public class MetricFamilySamplesBuilder {
 
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaMetricsCollector.class.getName());
     private final Collector.Type type;
     private final String help;
     private final List<Collector.MetricFamilySamples.Sample> samples;
@@ -57,5 +62,17 @@ public class MetricFamilySamplesBuilder {
             throw new IllegalStateException("There are no samples");
         }
         return new Collector.MetricFamilySamples(samples.get(0).name, type, help, samples);
+    }
+
+    public static Map<String, String> sanitizeLabels(Map<String, String> labels) {
+        return labels.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> Collector.sanitizeMetricName(e.getKey()),
+                        Map.Entry::getValue,
+                        (v1, v2) -> {
+                            LOG.warn("Ignoring metric value duplicate key {}", v1);
+                            return v1;
+                        },
+                        LinkedHashMap::new));
     }
 }

--- a/src/main/java/io/strimzi/kafka/metrics/YammerMetricsCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/YammerMetricsCollector.java
@@ -59,27 +59,27 @@ public class YammerMetricsCollector extends Collector {
                 Metric metric = entry.getValue();
                 LOG.trace("Collecting Yammer metric {}", metricName);
 
-                String name = metricName(metricName);
+                String prometheusMetricName = metricName(metricName);
                 // TODO Filtering should take labels into account
-                if (!config.isAllowed(name)) {
-                    LOG.info("Yammer metric {} is not allowed", name);
+                if (!config.isAllowed(prometheusMetricName)) {
+                    LOG.info("Yammer metric {} is not allowed", prometheusMetricName);
                     continue;
                 }
-                LOG.info("Yammer metric {} is allowed", name);
+                LOG.info("Yammer metric {} is allowed", prometheusMetricName);
                 Map<String, String> labels = labelsFromScope(metricName.getScope());
                 LOG.info("labels " + labels);
 
                 MetricFamilySamples sample = null;
                 if (metric instanceof Counter) {
-                    sample = convert(name, (Counter) metric, labels);
+                    sample = convert(prometheusMetricName, (Counter) metric, labels);
                 } else if (metric instanceof Gauge) {
-                    sample = convert(name, (Gauge<?>) metric, labels, metricName);
+                    sample = convert(prometheusMetricName, (Gauge<?>) metric, labels, metricName);
                 } else if (metric instanceof Histogram) {
-                    sample = convert(name, (Histogram) metric, labels);
+                    sample = convert(prometheusMetricName, (Histogram) metric, labels);
                 } else if (metric instanceof Meter) {
-                    sample = convert(name, (Meter) metric, labels);
+                    sample = convert(prometheusMetricName, (Meter) metric, labels);
                 } else if (metric instanceof Timer) {
-                    sample = convert(name, (Timer) metric, labels);
+                    sample = convert(prometheusMetricName, (Timer) metric, labels);
                 } else {
                     LOG.error("The metric " + metric.getClass().getName() + " has an unexpected type.");
                 }
@@ -115,19 +115,19 @@ public class YammerMetricsCollector extends Collector {
         return Collections.emptyMap();
     }
 
-    static MetricFamilySamples convert(String name, Counter counter, Map<String, String> labels) {
+    static MetricFamilySamples convert(String prometheusMetricName, Counter counter, Map<String, String> labels) {
         return new MetricFamilySamplesBuilder(Type.GAUGE, "")
-                .addSample(name + "_count", counter.count(), labels)
+                .addSample(prometheusMetricName + "_count", counter.count(), labels)
                 .build();
     }
 
-    static MetricFamilySamples convert(String name, Gauge<?> gauge, Map<String, String> labels, MetricName metricName) {
+    private static MetricFamilySamples convert(String prometheusMetricName, Gauge<?> gauge, Map<String, String> labels, MetricName metricName) {
         Map<String, String> sanitizedLabels = labels.entrySet().stream()
                 .collect(Collectors.toMap(
                         e -> Collector.sanitizeMetricName(e.getKey()),
                         Map.Entry::getValue,
                         (v1, v2) -> {
-                            LOG.warn("Unexpected duplicate key " + v1);
+                            LOG.warn("Ignoring metric value duplicate key {}", v1);
                             return v1;
                         },
                         LinkedHashMap::new));
@@ -142,27 +142,27 @@ public class YammerMetricsCollector extends Collector {
         }
 
         return new MetricFamilySamplesBuilder(Type.GAUGE, "")
-                .addSample(name, value, sanitizedLabels)
+                .addSample(prometheusMetricName, value, sanitizedLabels)
                 .build();
     }
 
-    static MetricFamilySamples convert(String name, Meter meter, Map<String, String> labels) {
+    static MetricFamilySamples convert(String prometheusMetricName, Meter meter, Map<String, String> labels) {
         return new MetricFamilySamplesBuilder(Type.COUNTER, "")
-                .addSample(name + "_count", meter.count(), labels)
+                .addSample(prometheusMetricName + "_count", meter.count(), labels)
                 .build();
     }
 
-    static MetricFamilySamples convert(String name, Histogram histogram, Map<String, String> labels) {
+    static MetricFamilySamples convert(String prometheusMetricName, Histogram histogram, Map<String, String> labels) {
         return new MetricFamilySamplesBuilder(Type.SUMMARY, "")
-                .addSample(name + "_count", histogram.count(), labels)
-                .addQuantileSamples(name, histogram.getSnapshot(), labels)
+                .addSample(prometheusMetricName + "_count", histogram.count(), labels)
+                .addQuantileSamples(prometheusMetricName, histogram.getSnapshot(), labels)
                 .build();
     }
 
-    static MetricFamilySamples convert(String name, Timer metric, Map<String, String> labels) {
+    static MetricFamilySamples convert(String prometheusMetricName, Timer metric, Map<String, String> labels) {
         return new MetricFamilySamplesBuilder(Type.SUMMARY, "")
-                .addSample(name + "_count", metric.count(), labels)
-                .addQuantileSamples(name, metric.getSnapshot(), labels)
+                .addSample(prometheusMetricName + "_count", metric.count(), labels)
+                .addQuantileSamples(prometheusMetricName, metric.getSnapshot(), labels)
                 .build();
     }
 }

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
@@ -50,7 +50,7 @@ public class KafkaMetricsCollectorTest {
         assertEquals(1, metrics.size());
 
         Collector.MetricFamilySamples metricFamilySamples = metrics.get(0);
-        assertMetricFamilySample(metricFamilySamples, "kafka_server_group_name", 1.0, labels);
+        assertMetricFamilySample(metricFamilySamples, 1.0, labels);
 
         // Adding the same metric updates its value
         collector.addMetric(buildMetric("name", "group", 3.0));
@@ -58,7 +58,7 @@ public class KafkaMetricsCollectorTest {
         assertEquals(1, metrics.size());
 
         Collector.MetricFamilySamples updatedMetrics = metrics.get(0);
-        assertMetricFamilySample(updatedMetrics, "kafka_server_group_name", 3.0, labels);
+        assertMetricFamilySample(updatedMetrics, 3.0, labels);
 
         // Removing the metric
         collector.removeMetric(buildMetric("name", "group", 4.0));
@@ -91,18 +91,16 @@ public class KafkaMetricsCollectorTest {
 
         assertEquals("kafka_server_group_name", metricFamilySamples.name);
         assertEquals(1, metricFamilySamples.samples.size());
-        assertMetricFamilySample(metricFamilySamples, "kafka_server_group_name", 1.0, expectedLabels);
+        assertMetricFamilySample(metricFamilySamples, 1.0, expectedLabels);
     }
 
-    private void assertMetricFamilySample(Collector.MetricFamilySamples actual, String expectedSampleName, double expectedValue, Map<String, String> expectedLabels) {
-        assertEquals(expectedSampleName, actual.name, "unexpected name");
-        assertEquals(1, actual.samples.size(), "unexpected number of samples");
+    private void assertMetricFamilySample(Collector.MetricFamilySamples actual, double expectedValue, Map<String, String> expectedLabels) {
 
         Collector.MetricFamilySamples.Sample actualSample = actual.samples.get(0);
 
-        assertEquals(actualSample.value, expectedValue, 0.1, "unexpected value");
-        assertEquals(new ArrayList<>(expectedLabels.keySet()), actualSample.labelNames, "sample has unexpected label names");
-        assertEquals(new ArrayList<>(expectedLabels.values()), actualSample.labelValues, "sample has unexpected label values");
+        assertEquals(actualSample.value, expectedValue, 0.1);
+        assertEquals(new ArrayList<>(expectedLabels.keySet()), actualSample.labelNames);
+        assertEquals(new ArrayList<>(expectedLabels.values()), actualSample.labelValues);
     }
 
     private KafkaMetric buildMetric(String name, String group, double value) {

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -82,8 +83,8 @@ public class KafkaMetricsCollectorTest {
         collector.addMetric(nonNumericMetric);
         metrics = collector.collect();
 
-        Map<String, String> expectedLabels = new HashMap<>(labels);
-        expectedLabels.put("kafka_server_group_name", nonNumericValue);
+        Map<String, String> expectedLabels = new LinkedHashMap<>(labels);
+        expectedLabels.put("name", nonNumericValue);
         assertEquals(1, metrics.size());
 
         Collector.MetricFamilySamples metricFamilySamples = metrics.get(0);
@@ -99,7 +100,7 @@ public class KafkaMetricsCollectorTest {
 
         Collector.MetricFamilySamples.Sample actualSample = actual.samples.get(0);
 
-        assertEquals(expectedValue, actualSample.value, 0.1, "unexpected value");
+        assertEquals(actualSample.value, expectedValue, 0.1, "unexpected value");
         assertEquals(new ArrayList<>(expectedLabels.keySet()), actualSample.labelNames, "sample has unexpected label names");
         assertEquals(new ArrayList<>(expectedLabels.values()), actualSample.labelValues, "sample has unexpected label values");
     }

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
@@ -11,6 +11,7 @@ import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Measurable;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -26,7 +27,13 @@ public class KafkaMetricsCollectorTest {
 
     private final MetricConfig metricConfig = new MetricConfig();
     private final Time time = Time.SYSTEM;
-    private final Map<String, String> labels = Map.of("key", "value");
+    private Map<String, String> labels;
+
+    @BeforeEach
+    public void setup() {
+        labels = new HashMap<>();
+        labels.put("key", "value");
+    }
 
     @Test
     public void testMetricLifecycle() {
@@ -90,7 +97,6 @@ public class KafkaMetricsCollectorTest {
         Collector.MetricFamilySamples metricFamilySamples = metrics.get(0);
 
         assertEquals("kafka_server_group_name", metricFamilySamples.name);
-        assertEquals(1, metricFamilySamples.samples.size());
         assertMetricFamilySample(metricFamilySamples, 1.0, expectedLabels);
     }
 
@@ -98,6 +104,7 @@ public class KafkaMetricsCollectorTest {
 
         Collector.MetricFamilySamples.Sample actualSample = actual.samples.get(0);
 
+        assertEquals(1, actual.samples.size());
         assertEquals(actualSample.value, expectedValue, 0.1);
         assertEquals(new ArrayList<>(expectedLabels.keySet()), actualSample.labelNames);
         assertEquals(new ArrayList<>(expectedLabels.values()), actualSample.labelValues);
@@ -113,8 +120,8 @@ public class KafkaMetricsCollectorTest {
                 time);
     }
 
-    private KafkaMetric buildNonNumericMetric(String name, String group, String nonNumericValue) {
-        Gauge<String> measurable = (config, now) -> nonNumericValue;
+    private KafkaMetric buildNonNumericMetric(String name, String group, String value) {
+        Gauge<String> measurable = (config, now) -> value;
         return new KafkaMetric(
                 new Object(),
                 new MetricName(name, group, "", labels),

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
 public class KafkaMetricsCollectorTest {
 
     private final MetricConfig metricConfig = new MetricConfig();
@@ -51,10 +50,15 @@ public class KafkaMetricsCollectorTest {
         metrics = collector.collect();
         assertTrue(metrics.isEmpty());
 
-        // Adding a non-numeric metric does nothing
-        collector.addMetric(buildNonNumericMetric("name2", "group"));
+        // Adding a non-numeric metric converted
+        KafkaMetric nonNumericMetric = buildNonNumericMetric("name", "group");
+        collector.addMetric(nonNumericMetric);
         metrics = collector.collect();
-        assertTrue(metrics.isEmpty());
+        assertEquals(1, metrics.size());
+        assertEquals("kafka_server_group_name", metrics.get(0).name);
+        assertEquals(1, metrics.get(0).samples.size());
+        assertEquals(1.0, metrics.get(0).samples.get(0).value, 1.0);
+        assertTrue(metrics.get(0).samples.get(0).labelNames.contains("value"));
 
         // Adding a metric that matches the allowlist
         collector.addMetric(buildMetric("name", "group", 1.0));

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporterTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporterTest.java
@@ -63,11 +63,11 @@ public class KafkaPrometheusMetricsReporterTest {
         KafkaMetric metric3 = buildNonNumericMetric("name3", "group");
         reporter.metricChange(metric3);
         metrics = getMetrics(port);
-        assertEquals(initialMetrics + 2, metrics.size());
+        assertEquals(initialMetrics + 3, metrics.size());
 
         reporter.metricRemoval(metric1);
         metrics = getMetrics(port);
-        assertEquals(initialMetrics + 1, metrics.size());
+        assertEquals(initialMetrics + 2, metrics.size());
 
         reporter.close();
     }

--- a/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
@@ -10,10 +10,7 @@ import com.yammer.metrics.core.MetricName;
 import io.prometheus.client.Collector;
 import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,7 +21,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 
 public class YammerMetricsCollectorTest {
 
@@ -38,7 +34,6 @@ public class YammerMetricsCollectorTest {
     }
 
     @Test
-    @Order(1)
     public void testMetricLifeCycle() {
         Map<String, String> props = new HashMap<>();
         props.put(PrometheusMetricsReporterConfig.ALLOWLIST_CONFIG, "kafka_server_group_name.*");
@@ -59,10 +54,10 @@ public class YammerMetricsCollectorTest {
         assertEquals(1, metrics.size());
 
         Collector.MetricFamilySamples metricFamilySamples = metrics.get(0);
-        Collector.MetricFamilySamples.Sample serverGroupNameSamples = metricFamilySamples.samples.get(0);
-
         assertEquals("kafka_server_group_name_type_count", metrics.get(0).name);
         assertEquals(1, metricFamilySamples.samples.size());
+
+        Collector.MetricFamilySamples.Sample serverGroupNameSamples = metricFamilySamples.samples.get(0);
         assertEquals(0.0, serverGroupNameSamples.value, 0.1);
         assertEquals(new ArrayList<>(tags.keySet()), serverGroupNameSamples.labelNames);
         assertEquals(new ArrayList<>(tags.values()), serverGroupNameSamples.labelValues);
@@ -72,12 +67,12 @@ public class YammerMetricsCollectorTest {
         metrics = collector.collect();
         assertEquals(1, metrics.size());
 
-        Collector.MetricFamilySamples metricFamilySamples1 = metrics.get(0);
-        Collector.MetricFamilySamples.Sample serverGroupNameSamples1 = metricFamilySamples1.samples.get(0);
+        metricFamilySamples = metrics.get(0);
+        serverGroupNameSamples = metricFamilySamples.samples.get(0);
 
-        assertEquals("kafka_server_group_name_type_count", metricFamilySamples1.name);
-        assertEquals(1, metricFamilySamples1.samples.size());
-        assertEquals(10.0, serverGroupNameSamples1.value, 0.1);
+        assertEquals("kafka_server_group_name_type_count", metricFamilySamples.name);
+        assertEquals(1, metricFamilySamples.samples.size());
+        assertEquals(10.0, serverGroupNameSamples.value, 0.1);
 
         // Removing the metric
         removeMetric("group", "name", "type");
@@ -86,7 +81,6 @@ public class YammerMetricsCollectorTest {
     }
 
     @Test
-    @Order(2)
     public void testCollectNonNumericMetric() {
         Map<String, String> props = new HashMap<>();
         props.put(PrometheusMetricsReporterConfig.ALLOWLIST_CONFIG, "kafka_server_group_name.*");
@@ -100,7 +94,7 @@ public class YammerMetricsCollectorTest {
         metrics = collector.collect();
 
         Map<String, String> expectedTags = new LinkedHashMap<>(tags);
-        expectedTags.put("value", "value");
+        expectedTags.put("type", "value");
         assertEquals(1, metrics.size());
 
         Collector.MetricFamilySamples metricFamilySamples = metrics.get(0);

--- a/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
@@ -100,19 +100,16 @@ public class YammerMetricsCollectorTest {
         Collector.MetricFamilySamples metricFamilySamples = metrics.get(0);
 
         assertEquals("kafka_server_group_name_type", metricFamilySamples.name);
-        assertEquals(1, metricFamilySamples.samples.size());
-        assertMetricFamilySample(metricFamilySamples, "kafka_server_group_name_type", 1.0, expectedTags);
+        assertMetricFamilySample(metricFamilySamples, expectedTags);
     }
 
-    private void assertMetricFamilySample(Collector.MetricFamilySamples actual, String expectedSampleName, double expectedValue, Map<String, String> expectedTags) {
-        assertEquals(expectedSampleName, actual.name, "unexpected name");
-        assertEquals(1, actual.samples.size(), "unexpected number of samples");
+    private void assertMetricFamilySample(Collector.MetricFamilySamples actual, Map<String, String> expectedTags) {
 
         Collector.MetricFamilySamples.Sample actualSample = actual.samples.get(0);
 
-        assertEquals(expectedValue, actualSample.value, 0.1, "unexpected value");
-        assertEquals(new ArrayList<>(expectedTags.keySet()), actualSample.labelNames, "sample has unexpected label names");
-        assertEquals(new ArrayList<>(expectedTags.values()), actualSample.labelValues, "sample has unexpected label values");
+        assertEquals(1.0, actualSample.value, 0.1, "unexpected value");
+        assertEquals(new ArrayList<>(expectedTags.keySet()), actualSample.labelNames);
+        assertEquals(new ArrayList<>(expectedTags.values()), actualSample.labelValues);
     }
 
     @Test

--- a/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
@@ -54,10 +54,11 @@ public class YammerMetricsCollectorTest {
         assertEquals(1, metrics.size());
 
         Collector.MetricFamilySamples metricFamilySamples = metrics.get(0);
+
         assertEquals("kafka_server_group_name_type_count", metrics.get(0).name);
-        assertEquals(1, metricFamilySamples.samples.size());
 
         Collector.MetricFamilySamples.Sample serverGroupNameSamples = metricFamilySamples.samples.get(0);
+
         assertEquals(0.0, serverGroupNameSamples.value, 0.1);
         assertEquals(new ArrayList<>(tags.keySet()), serverGroupNameSamples.labelNames);
         assertEquals(new ArrayList<>(tags.values()), serverGroupNameSamples.labelValues);
@@ -71,7 +72,6 @@ public class YammerMetricsCollectorTest {
         serverGroupNameSamples = metricFamilySamples.samples.get(0);
 
         assertEquals("kafka_server_group_name_type_count", metricFamilySamples.name);
-        assertEquals(1, metricFamilySamples.samples.size());
         assertEquals(10.0, serverGroupNameSamples.value, 0.1);
 
         // Removing the metric
@@ -107,7 +107,8 @@ public class YammerMetricsCollectorTest {
 
         Collector.MetricFamilySamples.Sample actualSample = actual.samples.get(0);
 
-        assertEquals(1.0, actualSample.value, 0.1, "unexpected value");
+        assertEquals(1, actual.samples.size());
+        assertEquals(1.0, actualSample.value, 0.1);
         assertEquals(new ArrayList<>(expectedTags.keySet()), actualSample.labelNames);
         assertEquals(new ArrayList<>(expectedTags.values()), actualSample.labelValues);
     }


### PR DESCRIPTION
Prometheus only supports numeric values for metrics. A few metrics emitted by Kafka brokers and clients have non-numeric values. This PR will move the non-numeric value to a label and then and set its value to 1.0,  to satisfy Prometheus only supporting numeric values.

Reported in the following issue:
https://github.com/strimzi/metrics-reporter/issues/8