### PR TITLE
Refactor maven-assembly-plugin so no uber jar is created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The implementation is currently still in progress.
 ## Build
 
 ```shell
-mvn package assembly:single
+mvn package 
 ```
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The implementation is currently still in progress.
 ## Build
 
 ```shell
-mvn package 
+mvn package
 ```
 
 ## Run

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <maven.dependency.version>3.6.1</maven.dependency.version>
     <maven.source.version>3.2.1</maven.source.version>
     <maven.jar.version>3.3.0</maven.jar.version>
-    <!-- <maven.assembly.version>3.4.2</maven.assembly.version> -->
+    <maven.assembly.version>3.4.2</maven.assembly.version>
     <maven.gpg.version>3.1.0</maven.gpg.version>
     <sonatype.nexus.staging>1.6.13</sonatype.nexus.staging>
 
@@ -230,6 +230,26 @@
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>${maven.assembly.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <tarLongFileMode>posix</tarLongFileMode>
+              <descriptors>
+                <descriptor>src/main/assembly/dist.xml</descriptor>
+              </descriptors>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/main/assembly/dist.xml
+++ b/src/main/assembly/dist.xml
@@ -1,0 +1,30 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>zip</id>
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <formats>
+        <format>tar.gz</format>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <includes>
+                <include>README*</include>
+                <include>LICENSE*</include>
+            </includes>
+            <fileMode>0644</fileMode>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <scope>runtime</scope>
+            <outputDirectory>libs</outputDirectory>
+            <fileMode>0644</fileMode>
+            <outputFileNameMapping>${artifact.groupId}.${artifact.artifactId}-${artifact.version}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
+        </dependencySet>
+    </dependencySets>
+</assembly>


### PR DESCRIPTION
This PR aims to deal with the following issue https://github.com/strimzi/metrics-reporter/issues/24. 
Previously, `metrics-reporter-1.0.0-SNAPSHOT-jar-with-dependencies.jar` was created with `maven-assembly-plugin`. To keep in line with other Strimzi projects, it was decided to create a dist.xml file and then normally produce the regular JARs and if needed a ZIP / TGZ archive with all the required dependencies.