### PR TITLE
Add warning log when duplicate leables are created or detected

### DIFF
--- a/src/main/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilder.java
+++ b/src/main/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilder.java
@@ -12,10 +12,13 @@ import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import io.prometheus.metrics.model.snapshots.Quantiles;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 
+import java.util.logging.Logger;
 /**
  * Builder methods to convert Kafka metrics into Prometheus metrics
  */
 public class DataPointSnapshotBuilder {
+
+    private static final Logger LOG = Logger.getLogger(DataPointSnapshotBuilder.class.getName());
 
     /**
      * Create a datapoint for a {@link InfoSnapshot} metric
@@ -24,8 +27,15 @@ public class DataPointSnapshotBuilder {
      * @param metricName The name of the new label
      * @return The {@link InfoSnapshot.InfoDataPointSnapshot} datapoint
      */
+
     public static InfoSnapshot.InfoDataPointSnapshot infoDataPoint(Labels labels, Object value, String metricName) {
-        Labels newLabels = labels.add(PrometheusNaming.sanitizeLabelName(metricName), String.valueOf(value));
+        String sanitizedMetricName = PrometheusNaming.sanitizeLabelName(metricName);
+        Labels newLabels = labels;
+        if (labels.contains(sanitizedMetricName)) {
+            LOG.warning("Ignoring metric value duplicate key: " + sanitizedMetricName);
+        } else {
+            newLabels = labels.add(sanitizedMetricName, String.valueOf(value));
+        }
         return InfoSnapshot.InfoDataPointSnapshot.builder()
                 .labels(newLabels)
                 .build();

--- a/src/main/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilder.java
+++ b/src/main/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilder.java
@@ -11,14 +11,15 @@ import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import io.prometheus.metrics.model.snapshots.Quantiles;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.logging.Logger;
 /**
  * Builder methods to convert Kafka metrics into Prometheus metrics
  */
 public class DataPointSnapshotBuilder {
 
-    private static final Logger LOG = Logger.getLogger(DataPointSnapshotBuilder.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(DataPointSnapshotBuilder.class.getName());
 
     /**
      * Create a datapoint for a {@link InfoSnapshot} metric
@@ -29,12 +30,12 @@ public class DataPointSnapshotBuilder {
      */
 
     public static InfoSnapshot.InfoDataPointSnapshot infoDataPoint(Labels labels, Object value, String metricName) {
-        String sanitizedMetricName = PrometheusNaming.sanitizeLabelName(metricName);
+        String newLabelName = PrometheusNaming.sanitizeLabelName(metricName);
         Labels newLabels = labels;
-        if (labels.contains(sanitizedMetricName)) {
-            LOG.warning("Ignoring metric value duplicate key: " + sanitizedMetricName);
+        if (labels.contains(newLabelName)) {
+            LOG.warn("Ignoring metric value duplicate key: {} from metric: {}",  newLabelName, metricName);
         } else {
-            newLabels = labels.add(sanitizedMetricName, String.valueOf(value));
+            newLabels = labels.add(newLabelName, String.valueOf(value));
         }
         return InfoSnapshot.InfoDataPointSnapshot.builder()
                 .labels(newLabels)

--- a/src/main/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilder.java
+++ b/src/main/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilder.java
@@ -28,7 +28,6 @@ public class DataPointSnapshotBuilder {
      * @param metricName The name of the new label
      * @return The {@link InfoSnapshot.InfoDataPointSnapshot} datapoint
      */
-
     public static InfoSnapshot.InfoDataPointSnapshot infoDataPoint(Labels labels, Object value, String metricName) {
         String newLabelName = PrometheusNaming.sanitizeLabelName(metricName);
         Labels newLabels = labels;

--- a/src/main/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilder.java
+++ b/src/main/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilder.java
@@ -32,8 +32,12 @@ public class DataPointSnapshotBuilder {
     public static InfoSnapshot.InfoDataPointSnapshot infoDataPoint(Labels labels, Object value, String metricName) {
         String newLabelName = PrometheusNaming.sanitizeLabelName(metricName);
         Labels newLabels = labels;
-        if (labels.contains(newLabelName)) {
-            LOG.warn("Ignoring metric value duplicate key: {} from metric: {}",  newLabelName, metricName);
+        String existingValue = labels.get(newLabelName);
+        if (existingValue != null) {
+            if (!String.valueOf(value).equals(existingValue)) {
+                LOG.warn("Unable to add new label because of duplicate key: {} with value: {} from metric: {}",
+                        newLabelName, value, metricName);
+            }
         } else {
             newLabels = labels.add(newLabelName, String.valueOf(value));
         }

--- a/src/main/java/io/strimzi/kafka/metrics/KafkaMetricsCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/KafkaMetricsCollector.java
@@ -96,7 +96,7 @@ public class KafkaMetricsCollector implements MultiCollector {
                 continue;
             }
             LOG.info("Kafka metric {} is allowed", prometheusMetricName);
-            Labels labels = labelsFromTags(metricName.tags());
+            Labels labels = labelsFromTags(metricName.tags(), metricName.name());
 
             Object valueObj = kafkaMetric.metricValue();
             if (valueObj instanceof Number) {
@@ -124,7 +124,7 @@ public class KafkaMetricsCollector implements MultiCollector {
                 .toLowerCase(Locale.ROOT);
     }
 
-    protected static Labels labelsFromTags(Map<String, String> tags) {
+    static Labels labelsFromTags(Map<String, String> tags, String metricName) {
         Labels.Builder builder = Labels.builder();
         Set<String> labelNames = new HashSet<>();
         for (Map.Entry<String, String> label : tags.entrySet()) {
@@ -132,7 +132,7 @@ public class KafkaMetricsCollector implements MultiCollector {
             if (labelNames.add(newLabelName)) {
                 builder.label(newLabelName, label.getValue());
             } else {
-                LOG.warn("Ignoring duplicate label key: {} with value: {}", newLabelName, label.getValue());
+                LOG.warn("Ignoring duplicate label key: {} with value: {} from metric: {} ", newLabelName, label.getValue(), metricName);
             }
         }
         return builder.build();

--- a/src/main/java/io/strimzi/kafka/metrics/YammerMetricsCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/YammerMetricsCollector.java
@@ -85,7 +85,7 @@ public class YammerMetricsCollector implements MultiCollector {
                     continue;
                 }
                 LOG.info("Yammer metric {} is allowed", prometheusMetricName);
-                Labels labels = labelsFromScope(metricName.getScope());
+                Labels labels = labelsFromScope(metricName.getScope(), prometheusMetricName);
                 LOG.info("labels {}", labels);
 
                 if (metric instanceof Counter) {
@@ -145,7 +145,7 @@ public class YammerMetricsCollector implements MultiCollector {
         return metricNameStr;
     }
 
-    static Labels labelsFromScope(String scope) {
+    static Labels labelsFromScope(String scope, String metricName) {
         Labels.Builder builder = Labels.builder();
         Set<String> labelNames = new HashSet<>();
         if (scope != null) {
@@ -156,7 +156,8 @@ public class YammerMetricsCollector implements MultiCollector {
                     if (labelNames.add(newLabelName)) {
                         builder.label(newLabelName, parts[i + 1]);
                     } else {
-                        LOG.warn("Duplicate label name {} in scope {}", newLabelName, scope);
+                        String value = parts[i + 1];
+                        LOG.warn("Ignoring duplicate label key: {} with value: {} from metric: {} ", newLabelName, value, metricName);
                     }
                 }
             }

--- a/src/main/java/io/strimzi/kafka/metrics/YammerMetricsCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/YammerMetricsCollector.java
@@ -32,9 +32,11 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Prometheus Collector to store and export metrics retrieved by {@link YammerPrometheusMetricsReporter}.
@@ -145,11 +147,17 @@ public class YammerMetricsCollector implements MultiCollector {
 
     static Labels labelsFromScope(String scope) {
         Labels.Builder builder = Labels.builder();
+        Set<String> labelNames = new HashSet<>();
         if (scope != null) {
             String[] parts = scope.split("\\.");
             if (parts.length % 2 == 0) {
                 for (int i = 0; i < parts.length; i += 2) {
-                    builder.label(PrometheusNaming.sanitizeLabelName(parts[i]), parts[i + 1]);
+                    String newLabelName = PrometheusNaming.sanitizeLabelName(parts[i]);
+                    if (labelNames.add(newLabelName)) {
+                        builder.label(newLabelName, parts[i + 1]);
+                    } else {
+                        LOG.warn("Duplicate label name {} in scope {}", newLabelName, scope);
+                    }
                 }
             }
         }

--- a/src/test/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilderTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilderTest.java
@@ -15,10 +15,9 @@ public class DataPointSnapshotBuilderTest {
 
     @Test
     public void testCollidingNewLabelIsIgnored() {
-        Labels labels = Labels.builder().label("k1", "v1").label("k2", "v2").build();
-        InfoSnapshot.InfoDataPointSnapshot snapshot = DataPointSnapshotBuilder.infoDataPoint(labels, "value", "k1");
-        assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
-        assertEquals("v1", snapshot.getLabels().get("k1"));
+        Labels labels = Labels.builder().label("k_1", "v1").label("k2", "v2").build();
+        InfoSnapshot.InfoDataPointSnapshot snapshot = DataPointSnapshotBuilder.infoDataPoint(labels, "value", "k-1");
+        assertEquals("v1", snapshot.getLabels().get("k_1"));
     }
 
 }

--- a/src/test/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilderTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilderTest.java
@@ -6,7 +6,6 @@ package io.strimzi.kafka.metrics;
 
 import io.prometheus.metrics.model.snapshots.InfoSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
-import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilderTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilderTest.java
@@ -6,6 +6,7 @@ package io.strimzi.kafka.metrics;
 
 import io.prometheus.metrics.model.snapshots.InfoSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
+import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,9 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class DataPointSnapshotBuilderTest {
 
     @Test
-    public void testNewLabelDuplicateWarning() {
+    public void testCollidingNewLabelIsIgnored() {
         Labels labels = Labels.builder().label("k1", "v1").label("k2", "v2").build();
         InfoSnapshot.InfoDataPointSnapshot snapshot = DataPointSnapshotBuilder.infoDataPoint(labels, "value", "k1");
+        assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
         assertEquals("v1", snapshot.getLabels().get("k1"));
     }
 

--- a/src/test/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilderTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilderTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.metrics;
+
+import io.prometheus.metrics.model.snapshots.InfoSnapshot;
+import io.prometheus.metrics.model.snapshots.Labels;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DataPointSnapshotBuilderTest {
+
+    @Test
+    public void testNewLabelDuplicateWarning() {
+        Labels labels = Labels.builder().label("k1", "v1").label("k2", "v2").build();
+        InfoSnapshot.InfoDataPointSnapshot snapshot = DataPointSnapshotBuilder.infoDataPoint(labels, "value", "k1");
+        assertEquals("v1", snapshot.getLabels().get("k1"));
+    }
+
+}

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
@@ -10,6 +10,7 @@ import io.prometheus.metrics.model.snapshots.InfoSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -106,6 +107,19 @@ public class KafkaMetricsCollectorTest {
         assertEquals(1, snapshot.getDataPoints().size());
         Labels expectedLabels = labels.add("name", nonNumericValue);
         assertEquals(expectedLabels, snapshot.getDataPoints().get(0).getLabels());
+    }
+
+    @Test
+    public void testLabelNameSanitizing() {
+        String labelName = PrometheusNaming.sanitizeLabelName("k-1");
+        assertEquals("k_1", labelName);
+    }
+
+    @Test
+    public void testLabelDuplicateWarning() {
+        Labels labels = Labels.builder().label("k1", "v1").build();
+        InfoSnapshot.InfoDataPointSnapshot snapshot = DataPointSnapshotBuilder.infoDataPoint(labels, "v1", "k1");
+        assertEquals("v1", snapshot.getLabels().get("k1"));
     }
 
     private void assertGaugeSnapshot(MetricSnapshot snapshot, double expectedValue, Labels expectedLabels) {

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
@@ -115,7 +115,8 @@ public class KafkaMetricsCollectorTest {
         tags.put("k-1", "v1");
         tags.put("k_1", "v2");
 
-        Labels labels = KafkaMetricsCollector.labelsFromTags(tags);
+        Labels labels = KafkaMetricsCollector.labelsFromTags(tags, "name");
+
         assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
         assertEquals("v1", labels.get("k_1"));
         assertEquals(1, labels.size());

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
@@ -110,16 +110,15 @@ public class KafkaMetricsCollectorTest {
     }
 
     @Test
-    public void testLabelNameSanitizing() {
-        String labelName = PrometheusNaming.sanitizeLabelName("k-1");
-        assertEquals("k_1", labelName);
-    }
+    public void testLabelsFromTags() {
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("k-1", "v1");
+        tags.put("k_1", "v2");
 
-    @Test
-    public void testLabelDuplicateWarning() {
-        Labels labels = Labels.builder().label("k1", "v1").build();
-        InfoSnapshot.InfoDataPointSnapshot snapshot = DataPointSnapshotBuilder.infoDataPoint(labels, "v1", "k1");
-        assertEquals("v1", snapshot.getLabels().get("k1"));
+        Labels labels = KafkaMetricsCollector.labelsFromTags(tags);
+        assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
+        assertEquals("v1", labels.get("k_1"));
+        assertEquals(1, labels.size());
     }
 
     private void assertGaugeSnapshot(MetricSnapshot snapshot, double expectedValue, Labels expectedLabels) {

--- a/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
@@ -116,13 +116,13 @@ public class YammerMetricsCollectorTest {
 
     @Test
     public void testLabelsFromScope() {
-        assertEquals(Labels.of("k1", "v1", "k2", "v2"), YammerMetricsCollector.labelsFromScope("k1.v1.k2.v2"));
-        assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope(null));
-        assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope("k1"));
-        assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope("k1."));
-        assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope("k1.v1.k"));
+        assertEquals(Labels.of("k1", "v1", "k2", "v2"), YammerMetricsCollector.labelsFromScope("k1.v1.k2.v2", "name"));
+        assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope(null, "name"));
+        assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope("k1", "name"));
+        assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope("k1.", "name"));
+        assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope("k1.v1.k", "name"));
 
-        Labels labels = YammerMetricsCollector.labelsFromScope("k-1.v1.k_1.v2");
+        Labels labels = YammerMetricsCollector.labelsFromScope("k-1.v1.k_1.v2", "name");
         assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
         assertEquals("v1", labels.get("k_1"));
         assertEquals(1, labels.size());

--- a/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
@@ -13,6 +13,7 @@ import io.prometheus.metrics.model.snapshots.InfoSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -120,6 +121,11 @@ public class YammerMetricsCollectorTest {
         assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope("k1"));
         assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope("k1."));
         assertEquals(Labels.EMPTY, YammerMetricsCollector.labelsFromScope("k1.v1.k"));
+
+        Labels labels = YammerMetricsCollector.labelsFromScope("k-1.v1.k_1.v2");
+        assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
+        assertEquals("v1", labels.get("k_1"));
+        assertEquals(1, labels.size());
     }
 
     public Counter newCounter(String group, String type, String name) {


### PR DESCRIPTION
The logic that handles non-numeric metrics is in the [DataPointSnapshotBuilder](https://github.com/strimzi/metrics-reporter/blob/main/src/main/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilder.java) class. [Here](https://github.com/strimzi/metrics-reporter/blob/main/src/main/java/io/strimzi/kafka/metrics/DataPointSnapshotBuilder.java#L28) is where a new label with a metric value is created.
Currently we unconditionally add our new label without checking if a label with the same name exists already.
This PR logs a warning if duplicate labes are detected rather than throwing an `IllegalArgumentException`