### PR TITLE
Move label filtering into KafkaPrometheusReporter and out of the KafkaPrometheusCollector

### DIFF
--- a/src/main/java/io/strimzi/kafka/metrics/KafkaMetricsCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/KafkaMetricsCollector.java
@@ -4,16 +4,13 @@
  */
 package io.strimzi.kafka.metrics;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.prometheus.metrics.model.registry.MultiCollector;
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
 import io.prometheus.metrics.model.snapshots.InfoSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
-import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.metrics.KafkaMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,32 +27,12 @@ public class KafkaMetricsCollector implements MultiCollector {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaMetricsCollector.class);
     private final Map<MetricName, MetricWrapper> metrics;
-    @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // This field is initialized in the setPrefix method
-    private String prefix;
 
     /**
      * Constructs a new KafkaMetricsCollector with provided configuration.
      */
     public KafkaMetricsCollector() {
         this.metrics = new ConcurrentHashMap<>();
-    }
-
-    /**
-     * Sets the prefix to be used for metric names. This is always called before addMetric/removeMetric
-     *
-     * @param prefix The prefix to set.
-     */
-    public void setPrefix(String prefix) {
-        this.prefix = PrometheusNaming.prometheusName(prefix);
-    }
-
-    /**
-     * This method is used to get the prefix that is used for metric names.
-     *
-     * @return The prefix used for metric names.
-     */
-    public String getPrefix() {
-        return prefix;
     }
 
     /**
@@ -73,15 +50,15 @@ public class KafkaMetricsCollector implements MultiCollector {
     /**
      * Removes a Kafka metric from collection.
      *
-     * @param metric The Kafka metric to remove.
+     * @param name The Kafka metric to remove.
      */
-    public void removeMetric(KafkaMetric metric) {
-        metrics.remove(metric.metricName());
+    public void removeMetric(MetricName name) {
+        metrics.remove(name);
     }
 
     /**
      * Called when the Prometheus server scrapes metrics.
-     * @return metrics that match the configured allowlist
+     * @return MetricSnapshots object that contains snapshots of metrics
      */
     @Override
     public MetricSnapshots collect() {

--- a/src/main/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporter.java
+++ b/src/main/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporter.java
@@ -33,11 +33,11 @@ public class KafkaPrometheusMetricsReporter implements MetricsReporter {
     private final PrometheusRegistry registry;
     @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // This field is initialized in the configure method
     private KafkaMetricsCollector collector;
-    @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // This field is initialized in the init method
+    @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // This field is initialized in the configure method
     private PrometheusMetricsReporterConfig config;
     @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // This field is initialized in the configure method
     private Optional<HTTPServer> httpServer;
-    @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // This field is initialized in the setPrefix method
+    @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // This field is initialized in the contextChange method
     private String prefix;
 
     /**

--- a/src/main/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporter.java
+++ b/src/main/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporter.java
@@ -52,24 +52,6 @@ public class KafkaPrometheusMetricsReporter implements MetricsReporter {
         this.registry = registry;
     }
 
-    /**
-     * Sets the prefix to be used for metric names. This is always called before addMetric/removeMetric
-     *
-     * @param prefix The prefix to set.
-     */
-    public void setPrefix(String prefix) {
-        this.prefix = PrometheusNaming.prometheusName(prefix);
-    }
-
-    /**
-     * This method is used to get the prefix that is used for metric names.
-     *
-     * @return The prefix used for metric names.
-     */
-    public String getPrefix() {
-        return prefix;
-    }
-
     @Override
     public void configure(Map<String, ?> map) {
         config = new PrometheusMetricsReporterConfig(map, registry);
@@ -89,7 +71,7 @@ public class KafkaPrometheusMetricsReporter implements MetricsReporter {
     }
 
     public void metricChange(KafkaMetric metric) {
-        String prometheusName = MetricWrapper.prometheusName(getPrefix(), metric.metricName());
+        String prometheusName = MetricWrapper.prometheusName(this.prefix, metric.metricName());
         if (!config.isAllowed(prometheusName)) {
             LOG.trace("Ignoring metric {} as it does not match the allowlist", prometheusName);
         } else {
@@ -124,7 +106,7 @@ public class KafkaPrometheusMetricsReporter implements MetricsReporter {
     @Override
     public void contextChange(MetricsContext metricsContext) {
         String prefix = metricsContext.contextLabels().get(MetricsContext.NAMESPACE);
-        setPrefix(prefix);
+        this.prefix = PrometheusNaming.prometheusName(prefix);
     }
 
     // for testing

--- a/src/main/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporter.java
+++ b/src/main/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporter.java
@@ -71,7 +71,7 @@ public class KafkaPrometheusMetricsReporter implements MetricsReporter {
     }
 
     public void metricChange(KafkaMetric metric) {
-        String prometheusName = MetricWrapper.prometheusName(this.prefix, metric.metricName());
+        String prometheusName = MetricWrapper.prometheusName(prefix, metric.metricName());
         if (!config.isAllowed(prometheusName)) {
             LOG.trace("Ignoring metric {} as it does not match the allowlist", prometheusName);
         } else {

--- a/src/main/java/io/strimzi/kafka/metrics/MetricWrapper.java
+++ b/src/main/java/io/strimzi/kafka/metrics/MetricWrapper.java
@@ -29,7 +29,6 @@ public class MetricWrapper {
     private final Object value;
     private final String attribute;
 
-    // Will be used when implementing https://github.com/strimzi/metrics-reporter/issues/9
     /**
      * Constructor from Kafka Metrics
      * @param prometheusName The name of the metric in the prometheus format
@@ -89,7 +88,7 @@ public class MetricWrapper {
         return attribute;
     }
 
-    private static Labels labelsFromScope(String scope, String metricName) {
+    static Labels labelsFromScope(String scope, String metricName) {
         Labels.Builder builder = Labels.builder();
         Set<String> labelNames = new HashSet<>();
         if (scope != null) {
@@ -108,8 +107,7 @@ public class MetricWrapper {
         return builder.build();
     }
 
-    // Will be used when implementing https://github.com/strimzi/metrics-reporter/issues/9
-    private static Labels labelsFromTags(Map<String, String> tags, String metricName) {
+    static Labels labelsFromTags(Map<String, String> tags, String metricName) {
         Labels.Builder builder = Labels.builder();
         Set<String> labelNames = new HashSet<>();
         for (Map.Entry<String, String> label : tags.entrySet()) {
@@ -137,7 +135,6 @@ public class MetricWrapper {
                         metricName.getName()).toLowerCase(Locale.ROOT));
     }
 
-    // Will be used when implementing https://github.com/strimzi/metrics-reporter/issues/9
     /**
      * Compute the Prometheus name from a Kafka MetricName
      * @param prefix The prefix to add to the metric name

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
@@ -4,13 +4,11 @@
  */
 package io.strimzi.kafka.metrics;
 
-import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
 import io.prometheus.metrics.model.snapshots.InfoSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
-import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -20,7 +18,6 @@ import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -28,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class KafkaMetricsCollectorTest {
-
     private final MetricConfig metricConfig = new MetricConfig();
     private final Time time = Time.SYSTEM;
     private Map<String, String> tagsMap;
@@ -47,31 +43,25 @@ public class KafkaMetricsCollectorTest {
     }
 
     @Test
-    public void testMetricLifecycle() {
-        Map<String, String> props = new HashMap<>();
-        props.put(PrometheusMetricsReporterConfig.ALLOWLIST_CONFIG, "kafka_server_group_name.*");
-        PrometheusMetricsReporterConfig config = new PrometheusMetricsReporterConfig(props, new PrometheusRegistry());
-        KafkaMetricsCollector collector = new KafkaMetricsCollector(config);
-        collector.setPrefix("kafka.server");
+    public void testCollect() {
+        KafkaMetricsCollector collector = new KafkaMetricsCollector();
 
         MetricSnapshots metrics = collector.collect();
         assertEquals(0, metrics.size());
 
-        // Adding a metric not matching the allowlist does nothing
-        collector.addMetric(buildMetric("name", "other", 2.0));
-        metrics = collector.collect();
-        assertEquals(0, metrics.size());
+        // Add a metric
+        MetricName metricName = new MetricName("name", "group", "description", tagsMap);
+        MetricWrapper metricWrapper = newMetric(metricName, 1.0);
 
-        // Adding a metric that matches the allowlist
-        collector.addMetric(buildMetric("name", "group", 1.0));
+        collector.addMetric(metricName, metricWrapper);
         metrics = collector.collect();
         assertEquals(1, metrics.size());
 
         MetricSnapshot snapshot = metrics.get(0);
         assertGaugeSnapshot(snapshot, 1.0, labels);
 
-        // Adding the same metric updates its value
-        collector.addMetric(buildMetric("name", "group", 3.0));
+        // Update the value of the metric
+        collector.addMetric(metricName, newMetric(metricName, 3.0));
         metrics = collector.collect();
         assertEquals(1, metrics.size());
 
@@ -79,17 +69,14 @@ public class KafkaMetricsCollectorTest {
         assertGaugeSnapshot(updatedSnapshot, 3.0, labels);
 
         // Removing the metric
-        collector.removeMetric(buildMetric("name", "group", 4.0));
+        collector.removeMetric(buildMetric("name", "group", 1.0));
         metrics = collector.collect();
         assertEquals(0, metrics.size());
     }
 
     @Test
     public void testCollectNonNumericMetric() {
-        Map<String, String> props = new HashMap<>();
-        props.put(PrometheusMetricsReporterConfig.ALLOWLIST_CONFIG, "kafka_server_group_name.*");
-        PrometheusMetricsReporterConfig config = new PrometheusMetricsReporterConfig(props, new PrometheusRegistry());
-        KafkaMetricsCollector collector = new KafkaMetricsCollector(config);
+        KafkaMetricsCollector collector = new KafkaMetricsCollector();
         collector.setPrefix("kafka.server");
 
         MetricSnapshots metrics = collector.collect();
@@ -97,8 +84,9 @@ public class KafkaMetricsCollectorTest {
 
         // Adding a non-numeric metric converted
         String nonNumericValue = "myValue";
-        KafkaMetric nonNumericMetric = buildNonNumericMetric("name", "group", nonNumericValue);
-        collector.addMetric(nonNumericMetric);
+        MetricName metricName = new MetricName("name", "group", "description", tagsMap);
+        MetricWrapper metricWrapper = newNonNumericMetric(metricName, nonNumericValue);
+        collector.addMetric(metricName, metricWrapper);
         metrics = collector.collect();
 
         assertEquals(1, metrics.size());
@@ -109,19 +97,6 @@ public class KafkaMetricsCollectorTest {
         assertEquals(expectedLabels, snapshot.getDataPoints().get(0).getLabels());
     }
 
-    @Test
-    public void testLabelsFromTags() {
-        Map<String, String> tags = new LinkedHashMap<>();
-        tags.put("k-1", "v1");
-        tags.put("k_1", "v2");
-
-        Labels labels = KafkaMetricsCollector.labelsFromTags(tags, "name");
-
-        assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
-        assertEquals("v1", labels.get("k_1"));
-        assertEquals(1, labels.size());
-    }
-
     private void assertGaugeSnapshot(MetricSnapshot snapshot, double expectedValue, Labels expectedLabels) {
         assertInstanceOf(GaugeSnapshot.class, snapshot);
         GaugeSnapshot gaugeSnapshot = (GaugeSnapshot) snapshot;
@@ -129,6 +104,12 @@ public class KafkaMetricsCollectorTest {
         GaugeSnapshot.GaugeDataPointSnapshot datapoint = gaugeSnapshot.getDataPoints().get(0);
         assertEquals(expectedValue, datapoint.getValue());
         assertEquals(expectedLabels, datapoint.getLabels());
+    }
+
+    private MetricWrapper newMetric(MetricName metricName, double value) {
+        KafkaMetric metric = buildMetric(metricName.name(), metricName.group(), value);
+        String prometheusName = MetricWrapper.prometheusName("kafka.server", metricName);
+        return new MetricWrapper(prometheusName, metric, metricName.name());
     }
 
     private KafkaMetric buildMetric(String name, String group, double value) {
@@ -141,14 +122,17 @@ public class KafkaMetricsCollectorTest {
                 time);
     }
 
-    private KafkaMetric buildNonNumericMetric(String name, String group, String value) {
-        Gauge<String> measurable = (config, now) -> value;
-        return new KafkaMetric(
+    private MetricWrapper newNonNumericMetric(MetricName metricName, String value) {
+        Gauge<String> gauge = (config, now) -> value;
+        KafkaMetric kafkaMetric = new KafkaMetric(
                 new Object(),
-                new MetricName(name, group, "", tagsMap),
-                measurable,
+                metricName,
+                gauge,
                 metricConfig,
-                time);
+                time
+        );
+        String prometheusName = MetricWrapper.prometheusName("kafka.server", metricName);
+        return new MetricWrapper(prometheusName, kafkaMetric, metricName.name());
     }
 
 }

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
@@ -25,12 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class KafkaMetricsCollectorTest {
+
+    private static final String METRIC_PREFIX = "kafka.server";
     private final MetricConfig metricConfig = new MetricConfig();
     private final Time time = Time.SYSTEM;
     private Map<String, String> tagsMap;
     private Labels labels;
-    private static final String METRIC_PREFIX = "kafka.server";
-
 
     @BeforeEach
     public void setup() {
@@ -53,7 +53,7 @@ public class KafkaMetricsCollectorTest {
 
         // Add a metric
         MetricName metricName = new MetricName("name", "group", "description", tagsMap);
-        MetricWrapper metricWrapper = buildMetric(metricName, 1.0);
+        MetricWrapper metricWrapper = newMetric(metricName, 1.0);
 
         collector.addMetric(metricName, metricWrapper);
         metrics = collector.collect();
@@ -63,7 +63,7 @@ public class KafkaMetricsCollectorTest {
         assertGaugeSnapshot(snapshot, 1.0, labels);
 
         // Update the value of the metric
-        collector.addMetric(metricName, buildMetric(metricName, 3.0));
+        collector.addMetric(metricName, newMetric(metricName, 3.0));
         metrics = collector.collect();
         assertEquals(1, metrics.size());
 
@@ -107,7 +107,7 @@ public class KafkaMetricsCollectorTest {
         assertEquals(expectedLabels, datapoint.getLabels());
     }
 
-    private MetricWrapper buildMetric(MetricName metricName, double value) {
+    private MetricWrapper newMetric(MetricName metricName, double value) {
         Measurable measurable = (config, now) -> value;
         KafkaMetric metric = new KafkaMetric(
                 new Object(),

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaMetricsCollectorTest.java
@@ -51,7 +51,7 @@ public class KafkaMetricsCollectorTest {
         MetricSnapshots metrics = collector.collect();
         assertEquals(0, metrics.size());
 
-        // Add a metric
+        // Adding a metric
         MetricName metricName = new MetricName("name", "group", "description", tagsMap);
         MetricWrapper metricWrapper = newMetric(metricName, 1.0);
 
@@ -62,7 +62,7 @@ public class KafkaMetricsCollectorTest {
         MetricSnapshot snapshot = metrics.get(0);
         assertGaugeSnapshot(snapshot, 1.0, labels);
 
-        // Update the value of the metric
+        // Updating the value of the metric
         collector.addMetric(metricName, newMetric(metricName, 3.0));
         metrics = collector.collect();
         assertEquals(1, metrics.size());
@@ -70,7 +70,7 @@ public class KafkaMetricsCollectorTest {
         MetricSnapshot updatedSnapshot = metrics.get(0);
         assertGaugeSnapshot(updatedSnapshot, 3.0, labels);
 
-        // Removing the metric
+        // Removing a metric
         collector.removeMetric(metricName);
         metrics = collector.collect();
         assertEquals(0, metrics.size());
@@ -109,14 +109,14 @@ public class KafkaMetricsCollectorTest {
 
     private MetricWrapper newMetric(MetricName metricName, double value) {
         Measurable measurable = (config, now) -> value;
-        KafkaMetric metric = new KafkaMetric(
+        KafkaMetric kafkaMetric = new KafkaMetric(
                 new Object(),
-                new MetricName(metricName.name(), metricName.group(), "", tagsMap),
+                metricName,
                 measurable,
                 metricConfig,
                 time);
         String prometheusName = MetricWrapper.prometheusName(METRIC_PREFIX, metricName);
-        return new MetricWrapper(prometheusName, metric, metricName.name());
+        return new MetricWrapper(prometheusName, kafkaMetric, metricName.name());
     }
 
     private MetricWrapper newNonNumericMetric(MetricName metricName, String value) {

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporterTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporterTest.java
@@ -44,27 +44,30 @@ public class KafkaPrometheusMetricsReporterTest {
 
         Optional<Integer> port = reporter.getPort();
         assertTrue(port.isPresent());
-
         int initialMetrics = getMetrics(port.get()).size();
-        KafkaMetric metric1 = buildMetric("name1", "group", 0);
+
+        // Adding a metric not matching the allowlist does nothing
+        KafkaMetric metric1 = buildMetric("other", "group", 0);
         reporter.init(Collections.singletonList(metric1));
-
         List<String> metrics = getMetrics(port.get());
-        assertEquals(initialMetrics + 1, metrics.size());
+        assertEquals(initialMetrics, metrics.size());
 
-        KafkaMetric metric2 = buildMetric("name2", "group", 0);
+        // Adding a metric not matching the allowlist does nothing
+        KafkaMetric metric2 = buildMetric("name", "group", 0);
         reporter.metricChange(metric2);
         metrics = getMetrics(port.get());
-        assertEquals(initialMetrics + 2, metrics.size());
+        assertEquals(initialMetrics + 1, metrics.size());
 
-        KafkaMetric metric3 = buildNonNumericMetric("name3", "group");
+        // Adding a non-numeric metric
+        KafkaMetric metric3 = buildNonNumericMetric("name1", "group");
         reporter.metricChange(metric3);
         metrics = getMetrics(port.get());
-        assertEquals(initialMetrics + 3, metrics.size());
-
-        reporter.metricRemoval(metric1);
-        metrics = getMetrics(port.get());
         assertEquals(initialMetrics + 2, metrics.size());
+
+        // Removing a metric
+        reporter.metricRemoval(metric3);
+        metrics = getMetrics(port.get());
+        assertEquals(initialMetrics + 1, metrics.size());
 
         reporter.close();
     }

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporterTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporterTest.java
@@ -76,7 +76,6 @@ public class KafkaPrometheusMetricsReporterTest {
     public void testMultipleReporters() throws Exception {
         Map<String, String> configs = new HashMap<>();
         configs.put(PrometheusMetricsReporterConfig.LISTENER_CONFIG, "http://:0");
-        configs.put(PrometheusMetricsReporterConfig.ALLOWLIST_CONFIG, "kafka_server_group_name.*");
 
         KafkaPrometheusMetricsReporter reporter1 = new KafkaPrometheusMetricsReporter(new PrometheusRegistry());
         reporter1.configure(configs);

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporterTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporterTest.java
@@ -38,12 +38,14 @@ public class KafkaPrometheusMetricsReporterTest {
         KafkaPrometheusMetricsReporter reporter = new KafkaPrometheusMetricsReporter(new PrometheusRegistry());
         Map<String, String> configs = new HashMap<>();
         configs.put(PrometheusMetricsReporterConfig.LISTENER_CONFIG, "http://:0");
+        configs.put(PrometheusMetricsReporterConfig.ALLOWLIST_CONFIG, "kafka_server_group_name.*");
         reporter.configure(configs);
         reporter.contextChange(new KafkaMetricsContext("kafka.server"));
+
         Optional<Integer> port = reporter.getPort();
         assertTrue(port.isPresent());
-        int initialMetrics = getMetrics(port.get()).size();
 
+        int initialMetrics = getMetrics(port.get()).size();
         KafkaMetric metric1 = buildMetric("name1", "group", 0);
         reporter.init(Collections.singletonList(metric1));
 
@@ -71,6 +73,7 @@ public class KafkaPrometheusMetricsReporterTest {
     public void testMultipleReporters() throws Exception {
         Map<String, String> configs = new HashMap<>();
         configs.put(PrometheusMetricsReporterConfig.LISTENER_CONFIG, "http://:0");
+        configs.put(PrometheusMetricsReporterConfig.ALLOWLIST_CONFIG, "kafka_server_group_name.*");
 
         KafkaPrometheusMetricsReporter reporter1 = new KafkaPrometheusMetricsReporter(new PrometheusRegistry());
         reporter1.configure(configs);

--- a/src/test/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporterTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/KafkaPrometheusMetricsReporterTest.java
@@ -42,31 +42,31 @@ public class KafkaPrometheusMetricsReporterTest {
         reporter.configure(configs);
         reporter.contextChange(new KafkaMetricsContext("kafka.server"));
 
-        Optional<Integer> port = reporter.getPort();
-        assertTrue(port.isPresent());
-        int initialMetrics = getMetrics(port.get()).size();
+        int port = reporter.getPort().orElseThrow();
+        // initialMetrics is used because JVM metrics are added to the registry
+        int initialMetrics = getMetrics(port).size();
 
         // Adding a metric not matching the allowlist does nothing
         KafkaMetric metric1 = buildMetric("other", "group", 0);
         reporter.init(Collections.singletonList(metric1));
-        List<String> metrics = getMetrics(port.get());
+        List<String> metrics = getMetrics(port);
         assertEquals(initialMetrics, metrics.size());
 
-        // Adding a metric not matching the allowlist does nothing
+        // Adding a metric that matches the allowlist
         KafkaMetric metric2 = buildMetric("name", "group", 0);
         reporter.metricChange(metric2);
-        metrics = getMetrics(port.get());
+        metrics = getMetrics(port);
         assertEquals(initialMetrics + 1, metrics.size());
 
         // Adding a non-numeric metric
         KafkaMetric metric3 = buildNonNumericMetric("name1", "group");
         reporter.metricChange(metric3);
-        metrics = getMetrics(port.get());
+        metrics = getMetrics(port);
         assertEquals(initialMetrics + 2, metrics.size());
 
         // Removing a metric
         reporter.metricRemoval(metric3);
-        metrics = getMetrics(port.get());
+        metrics = getMetrics(port);
         assertEquals(initialMetrics + 1, metrics.size());
 
         reporter.close();

--- a/src/test/java/io/strimzi/kafka/metrics/MetricWrapperTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/MetricWrapperTest.java
@@ -10,6 +10,8 @@ import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -17,21 +19,25 @@ public class MetricWrapperTest {
 
     @Test
     public void testLabelsFromScope() {
-        MetricWrapper mw = new MetricWrapper("", "k1.v1.k2.v2", null, "");
-        assertEquals(Labels.of("k1", "v1", "k2", "v2"), mw.labels());
-        mw = new MetricWrapper("", "k1.v1.k2.v2.", null, "");
-        assertEquals(Labels.of("k1", "v1", "k2", "v2"), mw.labels());
-        mw = new MetricWrapper("", null, null, "");
-        assertEquals(Labels.EMPTY, mw.labels());
-        mw = new MetricWrapper("", "k1", null, "");
-        assertEquals(Labels.EMPTY, mw.labels());
-        mw = new MetricWrapper("", "k1.", null, "");
-        assertEquals(Labels.EMPTY, mw.labels());
-        mw = new MetricWrapper("", "k1.v1.k", null, "");
-        assertEquals(Labels.EMPTY, mw.labels());
+        assertEquals(Labels.of("k1", "v1", "k2", "v2"), MetricWrapper.labelsFromScope("k1.v1.k2.v2", "name"));
+        assertEquals(Labels.EMPTY, MetricWrapper.labelsFromScope(null, "name"));
+        assertEquals(Labels.EMPTY, MetricWrapper.labelsFromScope("k1", "name"));
+        assertEquals(Labels.EMPTY, MetricWrapper.labelsFromScope("k1.", "name"));
+        assertEquals(Labels.EMPTY, MetricWrapper.labelsFromScope("k1.v1.k", "name"));
 
-        mw = new MetricWrapper("", "k-1.v1.k_1.v2", null, "");
-        Labels labels = mw.labels();
+        Labels labels = MetricWrapper.labelsFromScope("k-1.v1.k_1.v2", "name");
+        assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
+        assertEquals("v1", labels.get("k_1"));
+        assertEquals(1, labels.size());
+    }
+
+    @Test
+    public void testLabelsFromTags() {
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("k-1", "v1");
+        tags.put("k_1", "v2");
+        Labels labels = MetricWrapper.labelsFromTags(tags, "");
+
         assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
         assertEquals("v1", labels.get("k_1"));
         assertEquals(1, labels.size());

--- a/src/test/java/io/strimzi/kafka/metrics/MetricWrapperTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/MetricWrapperTest.java
@@ -34,10 +34,15 @@ public class MetricWrapperTest {
     @Test
     public void testLabelsFromTags() {
         Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("k1", "v1");
+        tags.put("k2", "v2");
+        Labels labels = MetricWrapper.labelsFromTags(tags, "");
+        assertEquals(Labels.of("k1", "v1", "k2", "v2"), labels);
+
+        tags = new LinkedHashMap<>();
         tags.put("k-1", "v1");
         tags.put("k_1", "v2");
-        Labels labels = MetricWrapper.labelsFromTags(tags, "");
-
+        labels = MetricWrapper.labelsFromTags(tags, "");
         assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
         assertEquals("v1", labels.get("k_1"));
         assertEquals(1, labels.size());


### PR DESCRIPTION
This PR is in response to the following issue: https://github.com/strimzi/metrics-reporter/issues/9
Moving the label filtering into the `metricChange` method means that filtering is done when the Reporter is initialised. It was previously done in the `collect` method.