### PR TITLE
Keep track of HTTPServer instances

### DIFF
--- a/src/main/java/io/strimzi/kafka/metrics/HttpServers.java
+++ b/src/main/java/io/strimzi/kafka/metrics/HttpServers.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.metrics;
+
+import io.prometheus.metrics.exporter.httpserver.HTTPServer;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Static class to keep track of all the HTTP servers started by all the Kafka components in a JVM.
+ */
+public class HttpServers {
+
+    private static final Map<Listener, ServerCounter> SERVERS = new HashMap<>();
+
+    /**
+     * Get or start a new HTTP server.
+     * @param listener The host and port
+     * @param registry The Prometheus registry to expose
+     * @return A ServerCounter instance
+     * @throws IOException if the HTTP server does not exist and cannot be started
+     */
+    public synchronized static ServerCounter get(Listener listener, PrometheusRegistry registry) throws IOException {
+        ServerCounter serverCounter = SERVERS.get(listener);
+        if (serverCounter == null) {
+            serverCounter = new ServerCounter(listener, registry);
+            SERVERS.put(listener, serverCounter);
+        }
+        serverCounter.count.incrementAndGet();
+        return serverCounter;
+    }
+
+    /**
+     * Release an HTTP server instance. If no other components hold this instance, it is closed.
+     * @param serverCounter The HTTP server instance to release
+     */
+    public synchronized static void release(ServerCounter serverCounter) {
+        if (serverCounter.close()) {
+            SERVERS.remove(serverCounter.listener);
+        }
+    }
+
+    /**
+     * Class used to keep track of the HTTP server started on a listener.
+     */
+    public static class ServerCounter {
+
+        private final AtomicInteger count;
+        private final HTTPServer server;
+        private final Listener listener;
+
+        private ServerCounter(Listener listener, PrometheusRegistry registry) throws IOException {
+            this.count = new AtomicInteger();
+            this.server = HTTPServer.builder()
+                    .hostname(listener.host)
+                    .port(listener.port)
+                    .registry(registry)
+                    .buildAndStart();
+            this.listener = listener;
+        }
+
+        /**
+         * The port this HTTP server instance is listening on. If the listener port is 0, this returns the actual port
+         * that is used.
+         * @return The port number
+         */
+        public int port() {
+            return server.getPort();
+        }
+
+        private synchronized boolean close() {
+            int remaining = count.decrementAndGet();
+            if (remaining == 0) {
+                server.close();
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/strimzi/kafka/metrics/HttpServers.java
+++ b/src/main/java/io/strimzi/kafka/metrics/HttpServers.java
@@ -13,20 +13,20 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Static class to keep track of all the HTTP servers started by all the Kafka components in a JVM.
+ * Class to keep track of all the HTTP servers started by all the Kafka components in a JVM.
  */
 public class HttpServers {
 
     private static final Map<Listener, ServerCounter> SERVERS = new HashMap<>();
 
     /**
-     * Get or start a new HTTP server.
+     * Get or create a new HTTP server if there isn't an existing instance for the specified listener.
      * @param listener The host and port
      * @param registry The Prometheus registry to expose
      * @return A ServerCounter instance
      * @throws IOException if the HTTP server does not exist and cannot be started
      */
-    public synchronized static ServerCounter get(Listener listener, PrometheusRegistry registry) throws IOException {
+    public synchronized static ServerCounter getOrCreate(Listener listener, PrometheusRegistry registry) throws IOException {
         ServerCounter serverCounter = SERVERS.get(listener);
         if (serverCounter == null) {
             serverCounter = new ServerCounter(listener, registry);

--- a/src/main/java/io/strimzi/kafka/metrics/HttpServers.java
+++ b/src/main/java/io/strimzi/kafka/metrics/HttpServers.java
@@ -6,6 +6,8 @@ package io.strimzi.kafka.metrics;
 
 import io.prometheus.metrics.exporter.httpserver.HTTPServer;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -17,6 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class HttpServers {
 
+    private final static Logger LOG = LoggerFactory.getLogger(HttpServers.class);
     private static final Map<Listener, ServerCounter> SERVERS = new HashMap<>();
 
     /**
@@ -62,6 +65,7 @@ public class HttpServers {
                     .port(listener.port)
                     .registry(registry)
                     .buildAndStart();
+            LOG.debug("Started HTTP server on http://{}:{}", listener.host, server.getPort());
             this.listener = listener;
         }
 
@@ -78,6 +82,7 @@ public class HttpServers {
             int remaining = count.decrementAndGet();
             if (remaining == 0) {
                 server.close();
+                LOG.debug("Stopped HTTP server on http://{}:{}", listener.host, server.getPort());
                 return true;
             }
             return false;

--- a/src/main/java/io/strimzi/kafka/metrics/Listener.java
+++ b/src/main/java/io/strimzi/kafka/metrics/Listener.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.metrics;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.strimzi.kafka.metrics.PrometheusMetricsReporterConfig.LISTENER_CONFIG;
+
+/**
+ * Class parsing and handling the listener specified via {@link PrometheusMetricsReporterConfig#LISTENER_CONFIG} for
+ * the HTTP server used to expose the metrics.
+ */
+public class Listener {
+
+    private static final Pattern PATTERN = Pattern.compile("http://\\[?([0-9a-zA-Z\\-%._:]*)]?:([0-9]+)");
+
+    final String host;
+    final int port;
+
+    /* test */ Listener(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    static Listener parseListener(String listener) {
+        Matcher matcher = PATTERN.matcher(listener);
+        if (matcher.matches()) {
+            String host = matcher.group(1);
+            int port = Integer.parseInt(matcher.group(2));
+            return new Listener(host, port);
+        } else {
+            throw new ConfigException(LISTENER_CONFIG, listener, "Listener must be of format http://[host]:[port]");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "http://" + host + ":" + port;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Listener listener = (Listener) o;
+        return port == listener.port && Objects.equals(host, listener.host);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(host, port);
+    }
+
+    /**
+     * Validator to check the user provided listener configuration
+     */
+    static class ListenerValidator implements ConfigDef.Validator {
+
+        @Override
+        public void ensureValid(String name, Object value) {
+            Matcher matcher = PATTERN.matcher(String.valueOf(value));
+            if (!matcher.matches()) {
+                throw new ConfigException(name, value, "Listener must be of format http://[host]:[port]");
+            }
+        }
+    }
+}

--- a/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
+++ b/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
@@ -144,7 +144,7 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
             return Optional.empty();
         }
         try {
-            HttpServers.ServerCounter server = HttpServers.get(listener, registry);
+            HttpServers.ServerCounter server = HttpServers.getOrCreate(listener, registry);
             LOG.info("HTTP server started on listener http://{}:{}", listener.host, server.port());
             return Optional.of(server);
         } catch (IOException ioe) {

--- a/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
+++ b/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.kafka.metrics;
 
-import io.prometheus.metrics.exporter.httpserver.HTTPServer;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -13,12 +12,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.BindException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -65,7 +61,7 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
     private static final String ALLOWLIST_CONFIG_DOC = "A comma separated list of regex patterns to specify the metrics to collect.";
 
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(LISTENER_CONFIG, ConfigDef.Type.STRING, LISTENER_CONFIG_DEFAULT, new ListenerValidator(), ConfigDef.Importance.HIGH, LISTENER_CONFIG_DOC)
+            .define(LISTENER_CONFIG, ConfigDef.Type.STRING, LISTENER_CONFIG_DEFAULT, new Listener.ListenerValidator(), ConfigDef.Importance.HIGH, LISTENER_CONFIG_DOC)
             .define(ALLOWLIST_CONFIG, ConfigDef.Type.LIST, ALLOWLIST_CONFIG_DEFAULT, ConfigDef.Importance.HIGH, ALLOWLIST_CONFIG_DOC)
             .define(LISTENER_ENABLE_CONFIG, ConfigDef.Type.BOOLEAN, LISTENER_ENABLE_CONFIG_DEFAULT, ConfigDef.Importance.HIGH, LISTENER_ENABLE_CONFIG_DOC);
 
@@ -140,80 +136,20 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
     /**
      * Start the HTTP server for exposing metrics.
      *
-     * @return An optional HTTPServer instance if started successfully, otherwise empty.
+     * @return An optional ServerCounter instance if {@link #LISTENER_ENABLE_CONFIG} is enabled, otherwise empty.
      */
-    public synchronized Optional<HTTPServer> startHttpServer() {
+    public synchronized Optional<HttpServers.ServerCounter> startHttpServer() {
         if (!listenerEnabled) {
             LOG.info("HTTP server listener not enabled");
             return Optional.empty();
         }
         try {
-            HTTPServer httpServer = HTTPServer.builder()
-                    .hostname(listener.host)
-                    .port(listener.port)
-                    .registry(registry)
-                    .buildAndStart();
-            LOG.info("HTTP server started on listener http://{}:{}", listener.host, httpServer.getPort());
-            return Optional.of(httpServer);
-        } catch (BindException be) {
-            LOG.info("HTTP server already started");
-            return Optional.empty();
+            HttpServers.ServerCounter server = HttpServers.get(listener, registry);
+            LOG.info("HTTP server started on listener http://{}:{}", listener.host, server.port());
+            return Optional.of(server);
         } catch (IOException ioe) {
             LOG.error("Failed starting HTTP server", ioe);
             throw new RuntimeException(ioe);
-        }
-    }
-
-    static class Listener {
-
-        private static final Pattern PATTERN = Pattern.compile("http://\\[?([0-9a-zA-Z\\-%._:]*)]?:([0-9]+)");
-
-        final String host;
-        final int port;
-
-        Listener(String host, int port) {
-            this.host = host;
-            this.port = port;
-        }
-
-        static Listener parseListener(String listener) {
-            Matcher matcher = PATTERN.matcher(listener);
-            if (matcher.matches()) {
-                String host = matcher.group(1);
-                int port = Integer.parseInt(matcher.group(2));
-                return new Listener(host, port);
-            } else {
-                throw new ConfigException(LISTENER_CONFIG, listener, "Listener must be of format http://[host]:[port]");
-            }
-        }
-
-        @Override
-         public String toString() {
-            return "http://" + host + ":" + port;
-        }
-
-        @Override
-         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Listener listener = (Listener) o;
-            return port == listener.port && Objects.equals(host, listener.host);
-        }
-
-        @Override
-         public int hashCode() {
-            return Objects.hash(host, port);
-        }
-    }
-
-    static class ListenerValidator implements ConfigDef.Validator {
-
-        @Override
-        public void ensureValid(String name, Object value) {
-            Matcher matcher = Listener.PATTERN.matcher(String.valueOf(value));
-            if (!matcher.matches()) {
-                throw new ConfigException(name, value, "Listener must be of format http://[host]:[port]");
-            }
         }
     }
 }

--- a/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
+++ b/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
@@ -145,7 +145,7 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
         }
         try {
             HttpServers.ServerCounter server = HttpServers.getOrCreate(listener, registry);
-            LOG.info("HTTP server started on listener http://{}:{}", listener.host, server.port());
+            LOG.info("HTTP server listening on http://{}:{}", listener.host, server.port());
             return Optional.of(server);
         } catch (IOException ioe) {
             LOG.error("Failed starting HTTP server", ioe);

--- a/src/test/java/io/strimzi/kafka/metrics/HttpServersTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/HttpServersTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.metrics;
+
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HttpServersTest {
+
+    private final PrometheusRegistry registry = new PrometheusRegistry();
+
+    @Test
+    public void testLifecycle() throws IOException {
+        Listener listener1 = Listener.parseListener("http://localhost:0");
+        HttpServers.ServerCounter server1 = HttpServers.get(listener1, registry);
+        assertTrue(listenerStarted(listener1.host, server1.port()));
+
+        Listener listener2 = Listener.parseListener("http://localhost:0");
+        HttpServers.ServerCounter server2 = HttpServers.get(listener2, registry);
+        assertTrue(listenerStarted(listener2.host, server2.port()));
+        assertSame(server1, server2);
+
+        Listener listener3 = Listener.parseListener("http://127.0.0.1:0");
+        HttpServers.ServerCounter server3 = HttpServers.get(listener3, registry);
+        assertTrue(listenerStarted(listener3.host, server3.port()));
+
+        HttpServers.release(server1);
+        assertTrue(listenerStarted(listener1.host, server1.port()));
+        assertTrue(listenerStarted(listener2.host, server2.port()));
+        assertTrue(listenerStarted(listener3.host, server3.port()));
+
+        HttpServers.release(server2);
+        assertFalse(listenerStarted(listener1.host, server1.port()));
+        assertFalse(listenerStarted(listener2.host, server2.port()));
+        assertTrue(listenerStarted(listener3.host, server3.port()));
+
+        HttpServers.release(server3);
+        assertFalse(listenerStarted(listener3.host, server3.port()));
+    }
+
+    private boolean listenerStarted(String host, int port) {
+        try {
+            URL url = new URL("http://" + host + ":" + port + "/metrics");
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("HEAD");
+            con.connect();
+            return con.getResponseCode() == HttpURLConnection.HTTP_OK;
+        } catch (IOException ioe) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/io/strimzi/kafka/metrics/HttpServersTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/HttpServersTest.java
@@ -22,16 +22,16 @@ public class HttpServersTest {
     @Test
     public void testLifecycle() throws IOException {
         Listener listener1 = Listener.parseListener("http://localhost:0");
-        HttpServers.ServerCounter server1 = HttpServers.get(listener1, registry);
+        HttpServers.ServerCounter server1 = HttpServers.getOrCreate(listener1, registry);
         assertTrue(listenerStarted(listener1.host, server1.port()));
 
         Listener listener2 = Listener.parseListener("http://localhost:0");
-        HttpServers.ServerCounter server2 = HttpServers.get(listener2, registry);
+        HttpServers.ServerCounter server2 = HttpServers.getOrCreate(listener2, registry);
         assertTrue(listenerStarted(listener2.host, server2.port()));
         assertSame(server1, server2);
 
         Listener listener3 = Listener.parseListener("http://127.0.0.1:0");
-        HttpServers.ServerCounter server3 = HttpServers.get(listener3, registry);
+        HttpServers.ServerCounter server3 = HttpServers.getOrCreate(listener3, registry);
         assertTrue(listenerStarted(listener3.host, server3.port()));
 
         HttpServers.release(server1);

--- a/src/test/java/io/strimzi/kafka/metrics/ListenerTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/ListenerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.metrics;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Test;
+
+import static io.strimzi.kafka.metrics.PrometheusMetricsReporterConfig.LISTENER_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ListenerTest {
+
+    @Test
+    public void testListenerParseListener() {
+        assertEquals(new Listener("", 8080), Listener.parseListener("http://:8080"));
+        assertEquals(new Listener("123", 8080), Listener.parseListener("http://123:8080"));
+        assertEquals(new Listener("::1", 8080), Listener.parseListener("http://::1:8080"));
+        assertEquals(new Listener("::1", 8080), Listener.parseListener("http://[::1]:8080"));
+        assertEquals(new Listener("random", 8080), Listener.parseListener("http://random:8080"));
+
+        assertThrows(ConfigException.class, () -> Listener.parseListener("http"));
+        assertThrows(ConfigException.class, () -> Listener.parseListener("http://"));
+        assertThrows(ConfigException.class, () -> Listener.parseListener("http://random"));
+        assertThrows(ConfigException.class, () -> Listener.parseListener("http://random:"));
+        assertThrows(ConfigException.class, () -> Listener.parseListener("http://:-8080"));
+        assertThrows(ConfigException.class, () -> Listener.parseListener("http://random:-8080"));
+        assertThrows(ConfigException.class, () -> Listener.parseListener("http://:8080random"));
+        assertThrows(ConfigException.class, () -> Listener.parseListener("randomhttp://:8080random"));
+        assertThrows(ConfigException.class, () -> Listener.parseListener("randomhttp://:8080"));
+    }
+
+    @Test
+    public void testValidator() {
+        Listener.ListenerValidator validator = new Listener.ListenerValidator();
+        validator.ensureValid(LISTENER_CONFIG, "http://:0");
+        validator.ensureValid(LISTENER_CONFIG, "http://123:8080");
+        validator.ensureValid(LISTENER_CONFIG, "http://::1:8080");
+        validator.ensureValid(LISTENER_CONFIG, "http://[::1]:8080");
+        validator.ensureValid(LISTENER_CONFIG, "http://random:8080");
+
+        assertThrows(ConfigException.class, () -> validator.ensureValid(LISTENER_CONFIG, "http"));
+        assertThrows(ConfigException.class, () -> validator.ensureValid(LISTENER_CONFIG, "http://"));
+        assertThrows(ConfigException.class, () -> validator.ensureValid(LISTENER_CONFIG, "http://random"));
+        assertThrows(ConfigException.class, () -> validator.ensureValid(LISTENER_CONFIG, "http://random:"));
+        assertThrows(ConfigException.class, () -> validator.ensureValid(LISTENER_CONFIG, "http://:-8080"));
+        assertThrows(ConfigException.class, () -> validator.ensureValid(LISTENER_CONFIG, "http://random:-8080"));
+        assertThrows(ConfigException.class, () -> validator.ensureValid(LISTENER_CONFIG, "http://:8080random"));
+        assertThrows(ConfigException.class, () -> validator.ensureValid(LISTENER_CONFIG, "randomhttp://:8080random"));
+        assertThrows(ConfigException.class, () -> validator.ensureValid(LISTENER_CONFIG, "randomhttp://:8080"));
+    }
+}


### PR DESCRIPTION
An attempt at addressing #34 by keeping track of all HTTPServer instances started so they can be properly closed whenever possible. You can have multiple HTTPServer instances when several Kafka components are started in the same JVM, for example in Kafka Connect or Kafka Streams. 

If multiple components attempt to create servers on the same listener, the same server will be reused. When all using components are shutdown, the server can also be closed.

