### PR TITLE
Correctly handle KafkaMetric metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,10 @@
             </goals>
             <configuration>
               <failOnWarning>true</failOnWarning>
+              <ignoredUnusedDeclaredDependencies>
+                <!-- Needed for logging in tests -->
+                <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-simple</ignoredUnusedDeclaredDependency>
+              </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,12 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/io/strimzi/kafka/metrics/MetricWrapper.java
+++ b/src/main/java/io/strimzi/kafka/metrics/MetricWrapper.java
@@ -26,7 +26,7 @@ public class MetricWrapper {
 
     private final String prometheusName;
     private final Labels labels;
-    private final Object value;
+    private final Object metric;
     private final String attribute;
 
     /**
@@ -38,7 +38,7 @@ public class MetricWrapper {
     public MetricWrapper(String prometheusName, KafkaMetric metric, String attribute) {
         this.prometheusName = prometheusName;
         this.labels = labelsFromTags(metric.metricName().tags(), prometheusName);
-        this.value = metric.metricValue();
+        this.metric = metric;
         this.attribute = attribute;
     }
 
@@ -52,7 +52,7 @@ public class MetricWrapper {
     public MetricWrapper(String prometheusName, String scope, Metric metric, String attribute) {
         this.prometheusName = prometheusName;
         this.labels = labelsFromScope(scope, prometheusName);
-        this.value = metric;
+        this.metric = metric;
         this.attribute = attribute;
     }
 
@@ -73,11 +73,11 @@ public class MetricWrapper {
     }
 
     /**
-     * The metric value
-     * @return The value
+     * The underlying metric
+     * @return The metric
      */
-    public Object value() {
-        return value;
+    public Object metric() {
+        return metric;
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/metrics/YammerMetricsCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/YammerMetricsCollector.java
@@ -64,7 +64,7 @@ public class YammerMetricsCollector implements MultiCollector {
         for (Map.Entry<MetricName, MetricWrapper> entry : metrics.entrySet()) {
             MetricWrapper metricWrapper = entry.getValue();
             String prometheusMetricName = metricWrapper.prometheusName();
-            Object metric = metricWrapper.value();
+            Object metric = metricWrapper.metric();
             Labels labels = metricWrapper.labels();
             LOG.debug("Collecting metric {} with the following labels: {}", prometheusMetricName, labels);
 

--- a/src/test/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfigTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfigTest.java
@@ -100,6 +100,9 @@ public class PrometheusMetricsReporterConfigTest {
         PrometheusMetricsReporterConfig config3 = new PrometheusMetricsReporterConfig(props, new PrometheusRegistry());
         Exception exc = assertThrows(RuntimeException.class, config3::startHttpServer);
         assertInstanceOf(BindException.class, exc.getCause());
+
+        HttpServers.release(httpServerOptional.get());
+        HttpServers.release(httpServerOptional2.get());
     }
 }
 

--- a/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/YammerMetricsCollectorTest.java
@@ -68,7 +68,7 @@ public class YammerMetricsCollectorTest {
         assertEquals(labels, datapoint.getLabels());
 
         // Update the value of the metric
-        ((Counter) metricWrapper.value()).inc(10);
+        ((Counter) metricWrapper.metric()).inc(10);
         metrics = collector.collect();
 
         assertEquals(1, metrics.size());


### PR DESCRIPTION
As described in #44 the collector was incorrectly caching the metric value, meaning that each collection reported the same initial value.

This also fixes a HTTP server leak in `PrometheusMetricsReporterConfigTest` which caused intermittent test flakiness. To find it I used `slf4j-simple` to get tracing output from the tests. Since it proved useful, I propose adding it as a test dependency.