### PR TITLE
Fix spotbugs errors and CI

### DIFF
--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -28,10 +28,6 @@ jobs:
       - template: '../steps/prerequisites/install_java.yaml'
         parameters:
           JDK_VERSION: $(jdk_version)
-      - bash: "mvn ${MVN_ARGS} spotbugs:check"
-        displayName: "Spotbugs"
-        env:
-          MVN_ARGS: "-e -V -B"
       - bash: "mvn ${MVN_ARGS} verify"
         displayName: "Build & Test Java"
         env:
@@ -39,6 +35,10 @@ jobs:
           BRANCH: $(Build.SourceBranch)
           TESTCONTAINERS_RYUK_DISABLED: "TRUE"
           TESTCONTAINERS_CHECKS_DISABLE: "TRUE"
+          MVN_ARGS: "-e -V -B"
+      - bash: "mvn ${MVN_ARGS} spotbugs:check"
+        displayName: "Spotbugs"
+        env:
           MVN_ARGS: "-e -V -B"
       # We have to TAR the target directory to maintain the permissions of
       # the files which would otherwise change when downloading the artifact

--- a/.spotbugs/spotbugs-exclude.xml
+++ b/.spotbugs/spotbugs-exclude.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
-  <!-- No excludes yet -->
+  <Match>
+    <!-- This allows us to use singleton pattern -->
+    <Bug pattern="MS_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <Bug pattern="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR"/>
+  </Match>
 </FindBugsFilter>

--- a/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
+++ b/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
@@ -13,7 +13,6 @@ import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,7 +23,7 @@ import java.util.stream.Collectors;
 /**
 * Configuration for the PrometheusMetricsReporter implementation.
 */
-public class PrometheusMetricsReporterConfig extends AbstractConfig {
+public final class PrometheusMetricsReporterConfig extends AbstractConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(PrometheusMetricsReporterConfig.class);
     private static final String CONFIG_PREFIX = "prometheus.metrics.reporter.";
@@ -145,13 +144,8 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
             LOG.info("HTTP server listener not enabled");
             return Optional.empty();
         }
-        try {
-            HttpServers.ServerCounter server = HttpServers.getOrCreate(listener, registry);
-            LOG.info("HTTP server listening on http://{}:{}", listener.host, server.port());
-            return Optional.of(server);
-        } catch (IOException ioe) {
-            LOG.error("Failed starting HTTP server", ioe);
-            throw new RuntimeException(ioe);
-        }
+        HttpServers.ServerCounter server = HttpServers.getOrCreate(listener, registry);
+        LOG.info("HTTP server listening on http://{}:{}", listener.host, server.port());
+        return Optional.of(server);
     }
 }

--- a/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
+++ b/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.kafka.metrics;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.strimzi.kafka.metrics.http.HttpServers;
 import io.strimzi.kafka.metrics.http.Listener;
@@ -77,6 +78,7 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
      * @param props the configuration properties.
      * @param registry the metrics registry
      */
+    @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     public PrometheusMetricsReporterConfig(Map<?, ?> props, PrometheusRegistry registry) {
         super(CONFIG_DEF, props);
         this.listener = Listener.parseListener(getString(LISTENER_CONFIG));
@@ -147,10 +149,5 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
         HttpServers.ServerCounter server = HttpServers.getOrCreate(listener, registry);
         LOG.info("HTTP server listening on http://{}:{}", listener.host, server.port());
         return Optional.of(server);
-    }
-
-    /** Prevent finalizer attack. */
-    protected final void finalize() {
-        // Do nothing
     }
 }

--- a/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
+++ b/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
@@ -148,4 +148,9 @@ public class PrometheusMetricsReporterConfig extends AbstractConfig {
         LOG.info("HTTP server listening on http://{}:{}", listener.host, server.port());
         return Optional.of(server);
     }
+
+    /** Prevent finalizer attack. */
+    protected final void finalize() {
+        // Do nothing
+    }
 }

--- a/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
+++ b/src/main/java/io/strimzi/kafka/metrics/PrometheusMetricsReporterConfig.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 /**
 * Configuration for the PrometheusMetricsReporter implementation.
 */
-public final class PrometheusMetricsReporterConfig extends AbstractConfig {
+public class PrometheusMetricsReporterConfig extends AbstractConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(PrometheusMetricsReporterConfig.class);
     private static final String CONFIG_PREFIX = "prometheus.metrics.reporter.";

--- a/src/main/java/io/strimzi/kafka/metrics/http/HttpServers.java
+++ b/src/main/java/io/strimzi/kafka/metrics/http/HttpServers.java
@@ -53,9 +53,9 @@ public class HttpServers {
      * Class used to keep track of the HTTP server started on a listener.
      */
     public static class ServerCounter {
-        private HTTPServer.Builder builder;
-        private Listener listener;
-        private AtomicInteger count;
+        private final HTTPServer.Builder builder;
+        private final Listener listener;
+        private final AtomicInteger count;
         private HTTPServer server;
 
         private ServerCounter(Listener listener, PrometheusRegistry registry) {
@@ -72,7 +72,7 @@ public class HttpServers {
         /**
          * Start the HTTP server.
          */
-        public void start() {
+        private void start() {
             try {
                 this.server = builder.buildAndStart();
                 LOG.debug("Started HTTP server on http://{}:{}", listener.host, server.getPort());

--- a/src/main/java/io/strimzi/kafka/metrics/http/HttpServers.java
+++ b/src/main/java/io/strimzi/kafka/metrics/http/HttpServers.java
@@ -27,12 +27,12 @@ public class HttpServers {
      * @param listener The host and port
      * @param registry The Prometheus registry to expose
      * @return A ServerCounter instance
-     * @throws IOException if the HTTP server does not exist and cannot be started
      */
-    public synchronized static ServerCounter getOrCreate(Listener listener, PrometheusRegistry registry) throws IOException {
+    public synchronized static ServerCounter getOrCreate(Listener listener, PrometheusRegistry registry) {
         ServerCounter serverCounter = SERVERS.get(listener);
         if (serverCounter == null) {
             serverCounter = new ServerCounter(listener, registry);
+            serverCounter.start();
             SERVERS.put(listener, serverCounter);
         }
         serverCounter.count.incrementAndGet();
@@ -53,22 +53,33 @@ public class HttpServers {
      * Class used to keep track of the HTTP server started on a listener.
      */
     public static class ServerCounter {
+        private HTTPServer.Builder builder;
+        private Listener listener;
+        private AtomicInteger count;
+        private HTTPServer server;
 
-        private final AtomicInteger count;
-        private final HTTPServer server;
-        private final Listener listener;
-
-        private ServerCounter(Listener listener, PrometheusRegistry registry) throws IOException {
-            this.count = new AtomicInteger();
-            HTTPServer.Builder builder = HTTPServer.builder()
-                    .port(listener.port)
-                    .registry(registry);
+        private ServerCounter(Listener listener, PrometheusRegistry registry) {
+            this.builder = HTTPServer.builder()
+                .port(listener.port)
+                .registry(registry);
             if (!listener.host.isEmpty()) {
                 builder.hostname(listener.host);
             }
-            this.server = builder.buildAndStart();
-            LOG.debug("Started HTTP server on http://{}:{}", listener.host, server.getPort());
             this.listener = listener;
+            this.count = new AtomicInteger();
+        }
+
+        /**
+         * Start the HTTP server.
+         */
+        public void start() {
+            try {
+                this.server = builder.buildAndStart();
+                LOG.debug("Started HTTP server on http://{}:{}", listener.host, server.getPort());
+            } catch (IOException e) {
+                LOG.error("Failed starting HTTP server", e);
+                throw new RuntimeException(e);
+            }
         }
 
         /**


### PR DESCRIPTION
Currently the spotbugs check on the CI is executed before project build, so it's a noop. This is the reason why we have a bunch of spotbugs errors that I'm also fixing here.

```sh
[INFO] BugInstance size is 8
[INFO] Error size is 0
[INFO] Total bugs: 8
[ERROR] Medium: io.strimzi.kafka.metrics.MetricWrapper.labels() may expose internal representation by returning MetricWrapper.labels [io.strimzi.kafka.metrics.MetricWrapper] At MetricWrapper.java:[line 39] EI_EXPOSE_REP
[ERROR] Medium: Public static io.strimzi.kafka.metrics.PrometheusCollector.register(PrometheusRegistry) may expose internal representation by returning PrometheusCollector.INSTANCE [io.strimzi.kafka.metrics.PrometheusCollector] At PrometheusCollector.java:[line 42] MS_EXPOSE_REP
[ERROR] Medium: Exception thrown in class io.strimzi.kafka.metrics.PrometheusMetricsReporterConfig at new io.strimzi.kafka.metrics.PrometheusMetricsReporterConfig(Map, PrometheusRegistry) will leave the constructor. The object under construction remains partially initialized and may be vulnerable to Finalizer attacks. [io.strimzi.kafka.metrics.PrometheusMetricsReporterConfig, io.strimzi.kafka.metrics.PrometheusMetricsReporterConfig] At PrometheusMetricsReporterConfig.java:[line 84]At PrometheusMetricsReporterConfig.java:[line 84] CT_CONSTRUCTOR_THROW
[ERROR] Medium: new io.strimzi.kafka.metrics.PrometheusMetricsReporterConfig(Map, PrometheusRegistry) may expose internal representation by storing an externally mutable object into PrometheusMetricsReporterConfig.registry [io.strimzi.kafka.metrics.PrometheusMetricsReporterConfig] At PrometheusMetricsReporterConfig.java:[line 86] EI_EXPOSE_REP2
[ERROR] Medium: Exception thrown in class io.strimzi.kafka.metrics.http.HttpServers$ServerCounter at new io.strimzi.kafka.metrics.http.HttpServers$ServerCounter(Listener, PrometheusRegistry) will leave the constructor. The object under construction remains partially initialized and may be vulnerable to Finalizer attacks. [io.strimzi.kafka.metrics.http.HttpServers$ServerCounter, io.strimzi.kafka.metrics.http.HttpServers$ServerCounter] At HttpServers.java:[line 69]At HttpServers.java:[line 69] CT_CONSTRUCTOR_THROW
[ERROR] Low: Overridable method addCollector is called from constructor new io.strimzi.kafka.metrics.kafka.KafkaCollector(PrometheusCollector). [io.strimzi.kafka.metrics.kafka.KafkaCollector] At KafkaCollector.java:[line 45] MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR
[ERROR] Medium: Public static io.strimzi.kafka.metrics.kafka.KafkaCollector.getCollector(PrometheusCollector) may expose internal representation by returning KafkaCollector.INSTANCE [io.strimzi.kafka.metrics.kafka.KafkaCollector] At KafkaCollector.java:[line 58] MS_EXPOSE_REP
[ERROR] Medium: Public static io.strimzi.kafka.metrics.yammer.YammerCollector.getCollector(PrometheusCollector) may expose internal representation by returning YammerCollector.INSTANCE [io.strimzi.kafka.metrics.yammer.YammerCollector] At YammerCollector.java:[line 62] MS_EXPOSE_REP
```