### PR TITLE
Bump Prometheus version to 1.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
 
     <kafka.version>3.8.1</kafka.version>
-    <prometheus.version>1.3.2</prometheus.version>
+    <prometheus.version>1.3.6</prometheus.version>
     <yammer.version>2.2.0</yammer.version>
     <slf4j.version>2.0.13</slf4j.version>
     <junit.version>5.10.2</junit.version>

--- a/src/main/java/io/strimzi/kafka/metrics/MetricsCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/MetricsCollector.java
@@ -18,5 +18,5 @@ public interface MetricsCollector {
      *
      * @return the list of metrics of this collector
      */
-    List<MetricSnapshot<?>> collect();
+    List<MetricSnapshot> collect();
 }

--- a/src/main/java/io/strimzi/kafka/metrics/PrometheusCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/PrometheusCollector.java
@@ -56,7 +56,7 @@ public class PrometheusCollector implements MultiCollector {
      */
     @Override
     public MetricSnapshots collect() {
-        List<MetricSnapshot<?>> snapshots = new ArrayList<>();
+        List<MetricSnapshot> snapshots = new ArrayList<>();
         for (MetricsCollector collector : collectors) {
             snapshots.addAll(collector.collect());
         }

--- a/src/main/java/io/strimzi/kafka/metrics/kafka/KafkaCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/kafka/KafkaCollector.java
@@ -83,7 +83,7 @@ public class KafkaCollector implements MetricsCollector {
      * @return the list of metrics of this collector
      */
     @Override
-    public List<MetricSnapshot<?>> collect() {
+    public List<MetricSnapshot> collect() {
         Map<String, MetricSnapshot.Builder<?>> builders = new HashMap<>();
         for (MetricWrapper metricWrapper : kafkaMetrics.values()) {
             String prometheusMetricName = metricWrapper.prometheusName();
@@ -100,7 +100,7 @@ public class KafkaCollector implements MetricsCollector {
                 builder.dataPoint(DataPointSnapshotBuilder.infoDataPoint(labels, metricValue, metricWrapper.attribute()));
             }
         }
-        List<MetricSnapshot<?>> snapshots = new ArrayList<>();
+        List<MetricSnapshot> snapshots = new ArrayList<>();
         for (MetricSnapshot.Builder<?> builder : builders.values()) {
             snapshots.add(builder.build());
         }

--- a/src/main/java/io/strimzi/kafka/metrics/yammer/YammerCollector.java
+++ b/src/main/java/io/strimzi/kafka/metrics/yammer/YammerCollector.java
@@ -88,7 +88,7 @@ public class YammerCollector implements MetricsCollector {
      */
     @SuppressWarnings({"CyclomaticComplexity", "JavaNCSS"})
     @Override
-    public List<MetricSnapshot<?>> collect() {
+    public List<MetricSnapshot> collect() {
         Map<String, MetricSnapshot.Builder<?>> builders = new HashMap<>();
         for (MetricWrapper metricWrapper : yammerMetrics.values()) {
             String prometheusMetricName = metricWrapper.prometheusName();
@@ -126,7 +126,7 @@ public class YammerCollector implements MetricsCollector {
                 LOG.error("The metric {} has an unexpected type: {}", prometheusMetricName, metric.getClass().getName());
             }
         }
-        List<MetricSnapshot<?>> snapshots = new ArrayList<>();
+        List<MetricSnapshot> snapshots = new ArrayList<>();
         for (MetricSnapshot.Builder<?> builder : builders.values()) {
             snapshots.add(builder.build());
         }

--- a/src/test/java/io/strimzi/kafka/metrics/PrometheusCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/PrometheusCollectorTest.java
@@ -45,7 +45,7 @@ public class PrometheusCollectorTest {
         Labels labels = Labels.of("l1", "v1", "l2", "v2");
         double value = 2.0;
         prometheusCollector.addCollector(() -> {
-            List<MetricSnapshot<?>> snapshots = new ArrayList<>();
+            List<MetricSnapshot> snapshots = new ArrayList<>();
             snapshots.add(GaugeSnapshot.builder()
                     .name("gauge")
                     .dataPoint(DataPointSnapshotBuilder.gaugeDataPoint(labels, value))
@@ -60,7 +60,7 @@ public class PrometheusCollectorTest {
         Quantiles quantiles = Quantiles.of(new Quantile(0.9, value));
         String metricName = "name";
         prometheusCollector.addCollector(() -> {
-            List<MetricSnapshot<?>> snapshots = new ArrayList<>();
+            List<MetricSnapshot> snapshots = new ArrayList<>();
             snapshots.add(InfoSnapshot.builder()
                     .name("info")
                     .dataPoint(DataPointSnapshotBuilder.infoDataPoint(labels, value, metricName))
@@ -79,8 +79,8 @@ public class PrometheusCollectorTest {
         assertSummarySnapshot(findSnapshot(snapshots, SummarySnapshot.class), count, value, labels, quantiles);
     }
 
-    private MetricSnapshot<?> findSnapshot(MetricSnapshots snapshots, Class<?> clazz) {
-        for (MetricSnapshot<?> snapshot : snapshots) {
+    private MetricSnapshot findSnapshot(MetricSnapshots snapshots, Class<?> clazz) {
+        for (MetricSnapshot snapshot : snapshots) {
             if (clazz.isInstance(snapshot)) {
                 return snapshot;
             }

--- a/src/test/java/io/strimzi/kafka/metrics/TestUtils.java
+++ b/src/test/java/io/strimzi/kafka/metrics/TestUtils.java
@@ -125,7 +125,7 @@ public class TestUtils {
      * @param expectedValue the expected value
      * @param expectedLabels the expected labels
      */
-    public static void assertGaugeSnapshot(MetricSnapshot<?> snapshot, double expectedValue, Labels expectedLabels) {
+    public static void assertGaugeSnapshot(MetricSnapshot snapshot, double expectedValue, Labels expectedLabels) {
         assertInstanceOf(GaugeSnapshot.class, snapshot);
         GaugeSnapshot gaugeSnapshot = (GaugeSnapshot) snapshot;
         assertEquals(1, gaugeSnapshot.getDataPoints().size());
@@ -140,7 +140,7 @@ public class TestUtils {
      * @param expectedValue the expected value
      * @param expectedLabels the expected labels
      */
-    public static void assertCounterSnapshot(MetricSnapshot<?> snapshot, double expectedValue, Labels expectedLabels) {
+    public static void assertCounterSnapshot(MetricSnapshot snapshot, double expectedValue, Labels expectedLabels) {
         assertInstanceOf(CounterSnapshot.class, snapshot);
         CounterSnapshot counterSnapshot = (CounterSnapshot) snapshot;
         assertEquals(1, counterSnapshot.getDataPoints().size());
@@ -156,7 +156,7 @@ public class TestUtils {
      * @param newLabelName the expected new label name
      * @param newLabelValue the expected new label value
      */
-    public static void assertInfoSnapshot(MetricSnapshot<?> snapshot, Labels labels, String newLabelName, String newLabelValue) {
+    public static void assertInfoSnapshot(MetricSnapshot snapshot, Labels labels, String newLabelName, String newLabelValue) {
         assertInstanceOf(InfoSnapshot.class, snapshot);
         InfoSnapshot infoSnapshot = (InfoSnapshot) snapshot;
         assertEquals(1, infoSnapshot.getDataPoints().size());
@@ -172,7 +172,7 @@ public class TestUtils {
      * @param expectedLabels the expected labels
      * @param expectedQuantiles the expected quantiles
      */
-    public static void assertSummarySnapshot(MetricSnapshot<?> snapshot, int expectedCount, double expectedSum, Labels expectedLabels, Quantiles expectedQuantiles) {
+    public static void assertSummarySnapshot(MetricSnapshot snapshot, int expectedCount, double expectedSum, Labels expectedLabels, Quantiles expectedQuantiles) {
         assertInstanceOf(SummarySnapshot.class, snapshot);
         SummarySnapshot summarySnapshot = (SummarySnapshot) snapshot;
         assertEquals(1, summarySnapshot.getDataPoints().size());

--- a/src/test/java/io/strimzi/kafka/metrics/kafka/KafkaCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/kafka/KafkaCollectorTest.java
@@ -45,7 +45,7 @@ public class KafkaCollectorTest {
     public void testCollectKafkaMetrics() {
         KafkaCollector collector = new KafkaCollector();
 
-        List<? extends MetricSnapshot<?>> metrics = collector.collect();
+        List<? extends MetricSnapshot> metrics = collector.collect();
         assertEquals(0, metrics.size());
 
         // Adding a metric
@@ -74,7 +74,7 @@ public class KafkaCollectorTest {
     public void testCollectNonNumericKafkaMetric() {
         KafkaCollector collector = new KafkaCollector();
 
-        List<? extends MetricSnapshot<?>> metrics = collector.collect();
+        List<? extends MetricSnapshot> metrics = collector.collect();
         assertEquals(0, metrics.size());
 
         // Adding a non-numeric metric converted
@@ -85,7 +85,7 @@ public class KafkaCollectorTest {
         metrics = collector.collect();
 
         assertEquals(1, metrics.size());
-        MetricSnapshot<?> snapshot = metrics.get(0);
+        MetricSnapshot snapshot = metrics.get(0);
         assertEquals(metricWrapper.prometheusName(), snapshot.getMetadata().getName());
         assertInfoSnapshot(snapshot, labels, "name", nonNumericValue);
     }

--- a/src/test/java/io/strimzi/kafka/metrics/yammer/YammerCollectorTest.java
+++ b/src/test/java/io/strimzi/kafka/metrics/yammer/YammerCollectorTest.java
@@ -41,7 +41,7 @@ public class YammerCollectorTest {
     public void testCollectYammerMetrics() {
         YammerCollector collector = new YammerCollector();
 
-        List<? extends MetricSnapshot<?>> metrics = collector.collect();
+        List<? extends MetricSnapshot> metrics = collector.collect();
         assertEquals(0, metrics.size());
 
         // Adding a metric
@@ -70,7 +70,7 @@ public class YammerCollectorTest {
     public void testCollectNonNumericYammerMetrics() {
         YammerCollector collector = new YammerCollector();
 
-        List<? extends MetricSnapshot<?>> metrics = collector.collect();
+        List<? extends MetricSnapshot> metrics = collector.collect();
         assertEquals(0, metrics.size());
 
         String nonNumericValue = "value";
@@ -80,7 +80,7 @@ public class YammerCollectorTest {
         metrics = collector.collect();
 
         assertEquals(1, metrics.size());
-        MetricSnapshot<?> snapshot = metrics.get(0);
+        MetricSnapshot snapshot = metrics.get(0);
         assertEquals(metricWrapper.prometheusName(), snapshot.getMetadata().getName());
         assertInfoSnapshot(snapshot, labels, "name", nonNumericValue);
     }


### PR DESCRIPTION
This trivial PR bumps the Prometheus version in order to align it with the HTTP bridge avoiding the metrics reporter bringing older dependencies when used within the bridge.