### PR TITLE
Add kafka.connect.mirror to the client namespaces

### DIFF
--- a/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/ClientMetricsReporter.java
+++ b/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/ClientMetricsReporter.java
@@ -37,6 +37,7 @@ public class ClientMetricsReporter extends AbstractReporter implements MetricsRe
             "kafka.consumer",
             "kafka.producer",
             "kafka.connect",
+            "kafka.connect.mirror",
             "kafka.streams"
     );
 
@@ -113,7 +114,8 @@ public class ClientMetricsReporter extends AbstractReporter implements MetricsRe
     public void contextChange(MetricsContext metricsContext) {
         String prefix = metricsContext.contextLabels().get(MetricsContext.NAMESPACE);
         if (!PREFIXES.contains(prefix)) {
-            throw new IllegalStateException("ClientMetricsReporter should only be used in Kafka clients");
+            throw new IllegalStateException("ClientMetricsReporter should only be used in Kafka clients. " +
+                    "Valid prefixes: " + PREFIXES + ", found " + prefix);
         }
         this.prefix = PrometheusNaming.prometheusName(prefix);
     }


### PR DESCRIPTION
MirrorMaker has its own metrics namespace defined in https://github.com/apache/kafka/blob/trunk/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java#L232

We need to include this in the client namespaces.