### PR TITLE
Add integration test for MirrorMaker connectors

### DIFF
--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
@@ -125,6 +125,13 @@ public class MetricsUtils {
         return metrics;
     }
 
+    /**
+     * Verify the container exposes metrics that match a condition
+     * @param container the container to check
+     * @param patterns the expected metrics patterns
+     * @param port the port on which metrics are exposed
+     * @param condition the assertion to execute on the metrics matching the patterns
+     */
     public static void verify(GenericContainer<?> container, List<String> patterns, int port, ThrowingConsumer<List<String>> condition) {
         assertTimeoutPreemptively(TIMEOUT, () -> {
             List<String> metrics = getMetrics(container.getHost(), container.getMappedPort(port));
@@ -145,6 +152,12 @@ public class MetricsUtils {
         });
     }
 
+    /**
+     * Start a test-clients container
+     * @param env the environment variables
+     * @param port the port to expose
+     * @return the container instance
+     */
     public static GenericContainer<?> clientContainer(Map<String, String> env, int port) {
         return new GenericContainer<>(CLIENTS_IMAGE)
                 .withNetwork(Network.SHARED)
@@ -181,5 +194,4 @@ public class MetricsUtils {
             }
         });
     }
-
 }

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
@@ -178,7 +178,6 @@ public class MetricsUtils {
     public static void startConnector(StrimziConnectCluster connect, String name, String config, int expectedTasks) {
         assertTimeoutPreemptively(TIMEOUT, () -> {
             HttpClient httpClient = HttpClient.newHttpClient();
-            System.out.println("starting connector " + name + " with config " + config);
             while (true) {
                 URI uri = new URI(connect.getRestEndpoint() + "/connectors/" + name + "/config");
                 HttpRequest request = HttpRequest.newBuilder()
@@ -188,7 +187,6 @@ public class MetricsUtils {
                         .build();
                 HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
                 try {
-                    System.out.println("response code: " + response.statusCode());
                     assertEquals(HttpURLConnection.HTTP_CREATED, response.statusCode());
                     break;
                 } catch (Throwable t) {
@@ -197,7 +195,6 @@ public class MetricsUtils {
                 }
             }
 
-            System.out.println("waiting for tasks to run");
             while (true) {
                 URI uri = new URI(connect.getRestEndpoint() + "/connectors/" + name + "/status");
                 HttpRequest request = HttpRequest.newBuilder()
@@ -207,7 +204,6 @@ public class MetricsUtils {
                 try {
                     assertEquals(HttpURLConnection.HTTP_OK, response.statusCode());
                     for (int taskId = 0; taskId < expectedTasks; taskId++) {
-                        System.out.println("checking task " + taskId + " " + response.body());
                         assertTrue(response.body().contains("{\"id\":" + taskId + ",\"state\":\"RUNNING\""));
                     }
                     break;

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
@@ -178,6 +178,7 @@ public class MetricsUtils {
     public static void startConnector(StrimziConnectCluster connect, String name, String config, int expectedTasks) {
         assertTimeoutPreemptively(TIMEOUT, () -> {
             HttpClient httpClient = HttpClient.newHttpClient();
+            // Wait for the connector creation to succeed
             while (true) {
                 URI uri = new URI(connect.getRestEndpoint() + "/connectors/" + name + "/config");
                 HttpRequest request = HttpRequest.newBuilder()
@@ -195,6 +196,7 @@ public class MetricsUtils {
                 }
             }
 
+            // Wait for the connector's tasks to be in RUNNING state
             while (true) {
                 URI uri = new URI(connect.getRestEndpoint() + "/connectors/" + name + "/status");
                 HttpRequest request = HttpRequest.newBuilder()

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
@@ -178,6 +178,7 @@ public class MetricsUtils {
     public static void startConnector(StrimziConnectCluster connect, String name, String config, int expectedTasks) {
         assertTimeoutPreemptively(TIMEOUT, () -> {
             HttpClient httpClient = HttpClient.newHttpClient();
+            System.out.println("starting connector " + name + " with config " + config);
             while (true) {
                 URI uri = new URI(connect.getRestEndpoint() + "/connectors/" + name + "/config");
                 HttpRequest request = HttpRequest.newBuilder()
@@ -187,6 +188,7 @@ public class MetricsUtils {
                         .build();
                 HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
                 try {
+                    System.out.println("response code: " + response.statusCode());
                     assertEquals(HttpURLConnection.HTTP_CREATED, response.statusCode());
                     break;
                 } catch (Throwable t) {
@@ -195,6 +197,7 @@ public class MetricsUtils {
                 }
             }
 
+            System.out.println("waiting for tasks to run");
             while (true) {
                 URI uri = new URI(connect.getRestEndpoint() + "/connectors/" + name + "/status");
                 HttpRequest request = HttpRequest.newBuilder()
@@ -204,6 +207,7 @@ public class MetricsUtils {
                 try {
                     assertEquals(HttpURLConnection.HTTP_OK, response.statusCode());
                     for (int taskId = 0; taskId < expectedTasks; taskId++) {
+                        System.out.println("checking task " + taskId + " " + response.body());
                         assertTrue(response.body().contains("{\"id\":" + taskId + ",\"state\":\"RUNNING\""));
                     }
                     break;

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
@@ -44,7 +44,7 @@ public class MetricsUtils {
 
     public static final String VERSION = "1.0.0-SNAPSHOT";
     private static final String CLIENTS_IMAGE = "quay.io/strimzi-test-clients/test-clients:latest-kafka-3.9.0";
-    private static final Duration TIMEOUT = Duration.ofSeconds(10L);
+    private static final Duration TIMEOUT = Duration.ofSeconds(30L);
 
     public static final String REPORTER_JARS = "target/client-metrics-reporter-" + VERSION + "/client-metrics-reporter-" + VERSION + "/libs/";
     public static final String MOUNT_PATH = "/opt/strimzi/metrics-reporter/";

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestConnectMetricsIT.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestConnectMetricsIT.java
@@ -169,7 +169,7 @@ public class TestConnectMetricsIT {
                 "  \"topics\": \"" + TOPIC + "\",\n" +
                 "  \"file\": \"" + FILE + "\"\n" +
                 "}";
-        MetricsUtils.startConnector(connect, SINK_CONNECTOR, connectorConfig);
+        MetricsUtils.startConnector(connect, SINK_CONNECTOR, connectorConfig, 1);
         checkMetricsExist(SINK_PATTERNS);
 
         // Start a source connector metrics and check its metrics
@@ -179,7 +179,7 @@ public class TestConnectMetricsIT {
                 "  \"topic\": \"" + TOPIC + "\",\n" +
                 "  \"file\": \"" + FILE + "\"\n" +
                 "}";
-        MetricsUtils.startConnector(connect, SOURCE_CONNECTOR, connectorConfig);
+        MetricsUtils.startConnector(connect, SOURCE_CONNECTOR, connectorConfig, 1);
         checkMetricsExist(SOURCE_PATTERNS);
     }
 
@@ -217,7 +217,7 @@ public class TestConnectMetricsIT {
                 "  \"topics\": \"" + TOPIC + "\",\n" +
                 "  \"file\": \"" + FILE + "\"\n" +
                 "}";
-        MetricsUtils.startConnector(connect, SINK_CONNECTOR, connectorConfig);
+        MetricsUtils.startConnector(connect, SINK_CONNECTOR, connectorConfig, 1);
         List<String> allowedSinkPatterns = List.of(
                 "kafka_connect_connector_metrics_.*" + SINK_CONNECTOR_PATTERN,
                 "kafka_connect_connect_worker_metrics_connector_count 1.0",
@@ -235,7 +235,7 @@ public class TestConnectMetricsIT {
                 "  \"topic\": \"" + TOPIC + "\",\n" +
                 "  \"file\": \"" + FILE + "\"\n" +
                 "}";
-        MetricsUtils.startConnector(connect, SOURCE_CONNECTOR, connectorConfig);
+        MetricsUtils.startConnector(connect, SOURCE_CONNECTOR, connectorConfig, 1);
         List<String> allowedSourcePatterns = List.of(
                 "kafka_connect_connector_metrics_.*" + SOURCE_CONNECTOR_PATTERN,
                 "kafka_connect_connect_worker_metrics_connector_count 2.0",

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestConnectMetricsIT.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestConnectMetricsIT.java
@@ -22,8 +22,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.MountableFile;
 
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -146,7 +148,10 @@ public class TestConnectMetricsIT {
         for (GenericContainer<?> worker : connect.getWorkers()) {
             worker.withCopyFileToContainer(MountableFile.forHostPath(MetricsUtils.REPORTER_JARS), MetricsUtils.MOUNT_PATH)
                     .withExposedPorts(8083, PORT)
-                    .withEnv(Map.of("CLASSPATH", MetricsUtils.MOUNT_PATH + "*"));
+                    .withEnv(Map.of("CLASSPATH", MetricsUtils.MOUNT_PATH + "*"))
+                    .waitingFor(new HttpWaitStrategy()
+                            .forPath("/health")
+                            .forStatusCode(HttpURLConnection.HTTP_OK));
         }
         connect.start();
     }

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestMirrorMakerMetricsIT.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestMirrorMakerMetricsIT.java
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.MountableFile;
 
+import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.Map;
 
@@ -68,7 +70,10 @@ public class TestMirrorMakerMetricsIT {
         for (GenericContainer<?> worker : connect.getWorkers()) {
             worker.withCopyFileToContainer(MountableFile.forHostPath(MetricsUtils.REPORTER_JARS), MetricsUtils.MOUNT_PATH)
                     .withExposedPorts(8083, PORT)
-                    .withEnv(Map.of("CLASSPATH", MetricsUtils.MOUNT_PATH + "*"));
+                    .withEnv(Map.of("CLASSPATH", MetricsUtils.MOUNT_PATH + "*"))
+                    .waitingFor(new HttpWaitStrategy()
+                            .forPath("/health")
+                            .forStatusCode(HttpURLConnection.HTTP_OK));
         }
         connect.start();
 

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestMirrorMakerMetricsIT.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestMirrorMakerMetricsIT.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.metrics.prometheus.integration;
+
+import io.strimzi.kafka.metrics.prometheus.ClientMetricsReporter;
+import io.strimzi.kafka.metrics.prometheus.ClientMetricsReporterConfig;
+import io.strimzi.kafka.metrics.prometheus.MetricsUtils;
+import io.strimzi.kafka.metrics.prometheus.http.Listener;
+import io.strimzi.test.container.StrimziConnectCluster;
+import io.strimzi.test.container.StrimziKafkaCluster;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.MountableFile;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class TestMirrorMakerMetricsIT {
+
+    private static final int PORT = Listener.parseListener(ClientMetricsReporterConfig.LISTENER_CONFIG_DEFAULT).port;
+    private static final String CONNECT_ID = "my-cluster";
+    private static final String TOPIC = "input";
+    private static final String GROUP = "my-group";
+    private static final String SOURCE_CONNECTOR = "source";
+    private static final String CHECKPOINT_CONNECTOR = "checkpoint";
+
+    private StrimziKafkaCluster source;
+    private StrimziKafkaCluster target;
+    private StrimziConnectCluster connect;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        source = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withNumberOfBrokers(1)
+                .withSharedNetwork()
+                .build();
+        source.start();
+
+        target = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withNumberOfBrokers(1)
+                .withSharedNetwork()
+                .build();
+        target.start();
+
+        connect = new StrimziConnectCluster.StrimziConnectClusterBuilder()
+                .withGroupId(CONNECT_ID)
+                .withKafkaCluster(source)
+                .withAdditionalConnectConfiguration(Map.of(
+                        CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, ClientMetricsReporter.class.getName()
+                ))
+                .build();
+        for (GenericContainer<?> worker : connect.getWorkers()) {
+            worker.withCopyFileToContainer(MountableFile.forHostPath(MetricsUtils.REPORTER_JARS), MetricsUtils.MOUNT_PATH)
+                    .withExposedPorts(8083, PORT)
+                    .withEnv(Map.of("CLASSPATH", MetricsUtils.MOUNT_PATH + "*"));
+        }
+        connect.start();
+
+        try (Admin admin = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, source.getBootstrapServers()))) {
+            // Create a topic with 2 partitions so we get 2 MirrorSourceConnector tasks
+            admin.createTopics(List.of(new NewTopic(TOPIC, 2, (short) -1))).all().get();
+            // Create 2 consumer groups so we get 2 MirrorCheckpointConnector tasks
+            admin.alterConsumerGroupOffsets(GROUP, Map.of(new TopicPartition(TOPIC, 0), new OffsetAndMetadata(1))).all().get();
+            admin.alterConsumerGroupOffsets(GROUP + "-2", Map.of(new TopicPartition(TOPIC, 0), new OffsetAndMetadata(1))).all().get();
+        }
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(Map.of(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, source.getBootstrapServers(),
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName(),
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()
+        ))) {
+            for (int i = 0; i < 5; i++) {
+                producer.send(new ProducerRecord<>(TOPIC, i % 2, null, "record" + i));
+            }
+        }
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (connect != null) {
+            connect.stop();
+        }
+        if (source != null) {
+            source.stop();
+        }
+        if (target != null) {
+            target.stop();
+        }
+    }
+
+    @Test
+    public void testMirrorMakerConnectorMetrics() {
+        // Start MirrorSourceConnector and check its metrics
+        String sourceTags = ".*partition=\"\\d+\",source=\"source\",target=\"target\",topic=\"source.input\".*";
+        List<String> sourceMetricsPatterns = List.of(
+                "kafka_connect_mirror_mirrorsourceconnector_byte_count" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_byte_rate" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_record_age_ms" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_record_age_ms_avg" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_record_age_ms_max" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_record_age_ms_min" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_record_count" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_record_rate" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_replication_latency_ms" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_replication_latency_ms_avg" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_replication_latency_ms_max" + sourceTags,
+                "kafka_connect_mirror_mirrorsourceconnector_replication_latency_ms_min" + sourceTags
+        );
+        String sourceConfig =
+                "{\n" +
+                "  \"name\": \"" + SOURCE_CONNECTOR + "\",\n" +
+                "  \"connector.class\": \"org.apache.kafka.connect.mirror.MirrorSourceConnector\",\n" +
+                "  \"tasks.max\": \"10\",\n" +
+                "  \"key.converter\": \"org.apache.kafka.connect.converters.ByteArrayConverter\",\n" +
+                "  \"value.converter\": \"org.apache.kafka.connect.converters.ByteArrayConverter\",\n" +
+                "  \"source.cluster.alias\": \"source\",\n" +
+                "  \"target.cluster.alias\": \"target\",\n" +
+                "  \"source.cluster.bootstrap.servers\": \"" + source.getNetworkBootstrapServers() + "\",\n" +
+                "  \"target.cluster.bootstrap.servers\": \"" + target.getNetworkBootstrapServers() + "\",\n" +
+                "  \"replication.factor\": \"-1\",\n" +
+                "  \"offset-syncs.topic.replication.factor\": \"-1\",\n" +
+                "  \"refresh.topics.interval.seconds\": \"1\",\n" +
+                "  \"topics\": \"" + TOPIC + "\",\n" +
+                "  \"metric.reporters\": \"" + ClientMetricsReporter.class.getName() + "\",\n" +
+                "  \"prometheus.metrics.reporter.listener.enable\": \"false\"" +
+                "}";
+        MetricsUtils.startConnector(connect, SOURCE_CONNECTOR, sourceConfig);
+        checkMetricsExist(sourceMetricsPatterns);
+
+        // Start MirrorCheckpointConnector and check its metrics
+        String checkpointTags = ".*group=\".*\",partition=\"\\d+\",source=\"source\",target=\"target\",topic=\"source.input\".*";
+        List<String> checkpointMetricPatterns = List.of(
+                "kafka_connect_mirror_mirrorcheckpointconnector_checkpoint_latency_ms" + checkpointTags,
+                "kafka_connect_mirror_mirrorcheckpointconnector_checkpoint_latency_ms_avg" + checkpointTags,
+                "kafka_connect_mirror_mirrorcheckpointconnector_checkpoint_latency_ms_max" + checkpointTags,
+                "kafka_connect_mirror_mirrorcheckpointconnector_checkpoint_latency_ms_min" + checkpointTags
+        );
+        String checkpointConfig =
+                "{\n" +
+                "  \"name\": \"" + CHECKPOINT_CONNECTOR + "\",\n" +
+                "  \"connector.class\": \"org.apache.kafka.connect.mirror.MirrorCheckpointConnector\",\n" +
+                "  \"tasks.max\": \"10\",\n" +
+                "  \"key.converter\": \"org.apache.kafka.connect.converters.ByteArrayConverter\",\n" +
+                "  \"value.converter\": \"org.apache.kafka.connect.converters.ByteArrayConverter\",\n" +
+                "  \"source.cluster.alias\": \"source\",\n" +
+                "  \"target.cluster.alias\": \"target\",\n" +
+                "  \"source.cluster.bootstrap.servers\": \"" + source.getNetworkBootstrapServers() + "\",\n" +
+                "  \"target.cluster.bootstrap.servers\": \"" + target.getNetworkBootstrapServers() + "\",\n" +
+                "  \"checkpoints.topic.replication.factor\": \"-1\",\n" +
+                "  \"emit.checkpoints.interval.seconds\": \"1\",\n" +
+                "  \"refresh.groups.interval.seconds\": \"1\",\n" +
+                "  \"metric.reporters\": \"" + ClientMetricsReporter.class.getName() + "\",\n" +
+                "  \"prometheus.metrics.reporter.listener.enable\": \"false\"" +
+                "}";
+        MetricsUtils.startConnector(connect, CHECKPOINT_CONNECTOR, checkpointConfig);
+        checkMetricsExist(checkpointMetricPatterns);
+    }
+
+    private void checkMetricsExist(List<String> patterns) {
+        for (GenericContainer<?> worker : connect.getWorkers()) {
+            MetricsUtils.verify(worker, patterns, PORT, metrics -> assertFalse(metrics.isEmpty()));
+        }
+    }
+}

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestMirrorMakerMetricsIT.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestMirrorMakerMetricsIT.java
@@ -93,6 +93,9 @@ public class TestMirrorMakerMetricsIT {
     @AfterEach
     public void tearDown() {
         if (connect != null) {
+            for (GenericContainer<?> container : connect.getWorkers()) {
+                System.out.println(container.getLogs());
+            }
             connect.stop();
         }
         if (source != null) {

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestMirrorMakerMetricsIT.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/integration/TestMirrorMakerMetricsIT.java
@@ -125,7 +125,7 @@ public class TestMirrorMakerMetricsIT {
                 "{\n" +
                 "  \"name\": \"" + SOURCE_CONNECTOR + "\",\n" +
                 "  \"connector.class\": \"org.apache.kafka.connect.mirror.MirrorSourceConnector\",\n" +
-                "  \"tasks.max\": \"10\",\n" +
+                "  \"tasks.max\": \"2\",\n" +
                 "  \"key.converter\": \"org.apache.kafka.connect.converters.ByteArrayConverter\",\n" +
                 "  \"value.converter\": \"org.apache.kafka.connect.converters.ByteArrayConverter\",\n" +
                 "  \"source.cluster.alias\": \"source\",\n" +
@@ -139,7 +139,7 @@ public class TestMirrorMakerMetricsIT {
                 "  \"metric.reporters\": \"" + ClientMetricsReporter.class.getName() + "\",\n" +
                 "  \"prometheus.metrics.reporter.listener.enable\": \"false\"" +
                 "}";
-        MetricsUtils.startConnector(connect, SOURCE_CONNECTOR, sourceConfig);
+        MetricsUtils.startConnector(connect, SOURCE_CONNECTOR, sourceConfig, 2);
         checkMetricsExist(sourceMetricsPatterns);
 
         // Start MirrorCheckpointConnector and check its metrics
@@ -154,7 +154,7 @@ public class TestMirrorMakerMetricsIT {
                 "{\n" +
                 "  \"name\": \"" + CHECKPOINT_CONNECTOR + "\",\n" +
                 "  \"connector.class\": \"org.apache.kafka.connect.mirror.MirrorCheckpointConnector\",\n" +
-                "  \"tasks.max\": \"10\",\n" +
+                "  \"tasks.max\": \"2\",\n" +
                 "  \"key.converter\": \"org.apache.kafka.connect.converters.ByteArrayConverter\",\n" +
                 "  \"value.converter\": \"org.apache.kafka.connect.converters.ByteArrayConverter\",\n" +
                 "  \"source.cluster.alias\": \"source\",\n" +
@@ -167,7 +167,7 @@ public class TestMirrorMakerMetricsIT {
                 "  \"metric.reporters\": \"" + ClientMetricsReporter.class.getName() + "\",\n" +
                 "  \"prometheus.metrics.reporter.listener.enable\": \"false\"" +
                 "}";
-        MetricsUtils.startConnector(connect, CHECKPOINT_CONNECTOR, checkpointConfig);
+        MetricsUtils.startConnector(connect, CHECKPOINT_CONNECTOR, checkpointConfig, 2);
         checkMetricsExist(checkpointMetricPatterns);
     }
 


### PR DESCRIPTION
Ignore the `kafka_connect_mirror_kafka_metrics_count_count` metric that gets registered by each MirrorMaker task.

Fixes #87, #88