### PR TITLE
Add #HELP message metric output

### DIFF
--- a/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollector.java
+++ b/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollector.java
@@ -97,7 +97,7 @@ public class KafkaCollector implements MetricsCollector {
                 Object metricValue = ((KafkaMetric) metricWrapper.metric()).metricValue();
                 Labels labels = metricWrapper.labels();
                 LOG.debug("Collecting Kafka metric {} with the following labels: {}", prometheusMetricName, labels);
-                String helpMessage = String.format("Use '" + prometheusMetricName + "' in allowlist");
+                String helpMessage = "Use " + prometheusMetricName + " in allowlist";
                 if (metricValue instanceof Number) {
                     double value = ((Number) metricValue).doubleValue();
                     GaugeSnapshot.Builder builder = (GaugeSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> GaugeSnapshot.builder().name(prometheusMetricName).help(helpMessage));

--- a/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollector.java
+++ b/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollector.java
@@ -97,13 +97,13 @@ public class KafkaCollector implements MetricsCollector {
                 Object metricValue = ((KafkaMetric) metricWrapper.metric()).metricValue();
                 Labels labels = metricWrapper.labels();
                 LOG.debug("Collecting Kafka metric {} with the following labels: {}", prometheusMetricName, labels);
-
+                String helpMessage = String.format("Use '" + prometheusMetricName + "' in allowlist");
                 if (metricValue instanceof Number) {
                     double value = ((Number) metricValue).doubleValue();
-                    GaugeSnapshot.Builder builder = (GaugeSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> GaugeSnapshot.builder().name(prometheusMetricName));
+                    GaugeSnapshot.Builder builder = (GaugeSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> GaugeSnapshot.builder().name(prometheusMetricName).help(helpMessage));
                     builder.dataPoint(DataPointSnapshotBuilder.gaugeDataPoint(labels, value));
                 } else {
-                    InfoSnapshot.Builder builder = (InfoSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> InfoSnapshot.builder().name(prometheusMetricName));
+                    InfoSnapshot.Builder builder = (InfoSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> InfoSnapshot.builder().name(prometheusMetricName).help(helpMessage));
                     builder.dataPoint(DataPointSnapshotBuilder.infoDataPoint(labels, metricValue, metricWrapper.attribute()));
                 }
             }

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ClientMetricsReporterTest.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ClientMetricsReporterTest.java
@@ -126,4 +126,28 @@ public class ClientMetricsReporterTest {
         }
     }
 
+    @Test
+    public void testHelpMessageInOutput() throws Exception {
+        ClientMetricsReporter reporter = new ClientMetricsReporter(registry, kafkaCollector);
+        configs.put(ClientMetricsReporterConfig.ALLOWLIST_CONFIG, "kafka_producer_group_name.*");
+        reporter.configure(configs);
+        reporter.contextChange(new KafkaMetricsContext("kafka.producer"));
+
+        int port = reporter.getPort().orElseThrow();
+
+        // Add a metric that matches the allowlist
+        KafkaMetric metric = newKafkaMetric("name", "group", (config, now) -> 0, LABELS);
+        reporter.metricChange(metric);
+
+        // Get metrics  including comments
+        List<String> metrics = getMetrics(port, true);
+
+        // Verify that the metrics contains the "Use prometheusMetricName in allowlist" help line
+        boolean foundHelpLine = metrics.stream()
+                .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use kafka_producer_group_name") && line.contains("in allowlist"));
+        assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use prometheusMetricName in allowlist' message");
+
+        reporter.close();
+    }
+
 }

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ClientMetricsReporterTest.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ClientMetricsReporterTest.java
@@ -7,6 +7,7 @@ package io.strimzi.kafka.metrics.prometheus;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.strimzi.kafka.metrics.prometheus.common.PrometheusCollector;
 import io.strimzi.kafka.metrics.prometheus.kafka.KafkaCollector;
+import io.strimzi.kafka.metrics.prometheus.kafka.KafkaMetricWrapper;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -142,10 +143,12 @@ public class ClientMetricsReporterTest {
         // Get metrics  including comments
         List<String> metrics = getMetrics(port, true);
 
+        String expectedPrometheusName = KafkaMetricWrapper.prometheusName("kafka.producer", metric.metricName());
+
         // Verify that the metrics contains the "Use prometheusMetricName in allowlist" help line
         boolean foundHelpLine = metrics.stream()
-                .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use kafka_producer_group_name") && line.contains("in allowlist"));
-        assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use prometheusMetricName in allowlist' message");
+                .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use " + expectedPrometheusName) && line.contains("in allowlist"));
+        assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use " + expectedPrometheusName + "in allowlist' message");
 
         reporter.close();
     }

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ClientMetricsReporterTest.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ClientMetricsReporterTest.java
@@ -147,7 +147,7 @@ public class ClientMetricsReporterTest {
 
         // Verify that the metrics contains the "Use prometheusMetricName in allowlist" help line
         boolean foundHelpLine = metrics.stream()
-                .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use " + expectedPrometheusName) && line.contains("in allowlist"));
+                .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use " + expectedPrometheusName + " in allowlist"));
         assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use " + expectedPrometheusName + "in allowlist' message");
 
         reporter.close();

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/MetricsUtils.java
@@ -60,11 +60,32 @@ public class MetricsUtils {
 
     /**
      * Query the HTTP endpoint and returns the output
+     * @param port The port to query
+     * @param includeComments Whether to include comment lines starting with #
+     * @return The lines from the output
+     */
+    public static List<String> getMetrics(int port, boolean includeComments) {
+        return getMetrics("localhost", port, includeComments);
+    }
+
+    /**
+     * Query the HTTP endpoint and returns the output
      * @param host The host to query
      * @param port The port to query
      * @return The lines from the output
      */
     public static List<String> getMetrics(String host, int port) {
+        return getMetrics(host, port, false);
+    }
+
+    /**
+     * Query the HTTP endpoint and returns the output
+     * @param host The host to query
+     * @param port The port to query
+     * @param includeComments Whether to include comment lines starting with #
+     * @return The lines from the output
+     */
+    public static List<String> getMetrics(String host, int port, boolean includeComments) {
         List<String> metrics = new ArrayList<>();
         assertTimeoutPreemptively(TIMEOUT, () -> {
             try {
@@ -74,7 +95,7 @@ public class MetricsUtils {
                 try (BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
                     String inputLine;
                     while ((inputLine = in.readLine()) != null) {
-                        if (!inputLine.startsWith("#")) {
+                        if (includeComments || !inputLine.startsWith("#")) {
                             metrics.add(inputLine);
                         }
                     }

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollectorTest.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollectorTest.java
@@ -126,32 +126,28 @@ public class KafkaCollectorTest {
         collector.addReporter(reporter);
 
         // Test numeric metric
-        AtomicInteger value = new AtomicInteger(1);
         MetricName numericMetricName = new MetricName("testMetric", "testGroup", "description", tagsMap);
-        MetricWrapper metricWrapper = newKafkaMetricWrapper(numericMetricName, (config, now) -> value.get());
+        MetricWrapper metricWrapper = newKafkaMetricWrapper(numericMetricName, (config, now) -> new AtomicInteger(1).get());
         reporter.addMetric(numericMetricName, metricWrapper);
 
         List<? extends MetricSnapshot> metrics = collector.collect();
         assertEquals(1, metrics.size());
-        MetricSnapshot snapshot = metrics.get(0);
 
         String expectedHelpMessage = "Use " + metricWrapper.prometheusName() + " in allowlist";
-        assertEquals(expectedHelpMessage, snapshot.getMetadata().getHelp());
+        assertEquals(expectedHelpMessage, metrics.get(0).getMetadata().getHelp());
 
         reporter.removeMetric(numericMetricName);
 
         // Test non-numeric metric
-        String nonNumericValue = "testValue";
         MetricName stringMetricName = new MetricName("stringMetric", "testGroup", "description", tagsMap);
-        MetricWrapper stringMetricWrapper = newKafkaMetricWrapper(stringMetricName, (config, now) -> nonNumericValue);
+        MetricWrapper stringMetricWrapper = newKafkaMetricWrapper(stringMetricName, (config, now) -> "testValue");
         reporter.addMetric(stringMetricName, stringMetricWrapper);
 
         metrics = collector.collect();
         assertEquals(1, metrics.size());
-        MetricSnapshot stringSnapshot = metrics.get(0);
 
         expectedHelpMessage = "Use " + stringMetricWrapper.prometheusName() + " in allowlist";
-        assertEquals(expectedHelpMessage, stringSnapshot.getMetadata().getHelp());
+        assertEquals(expectedHelpMessage, metrics.get(0).getMetadata().getHelp());
     }
 
     private MetricWrapper newKafkaMetricWrapper(MetricName metricName, Gauge<?> gauge) {

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollectorTest.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollectorTest.java
@@ -114,6 +114,57 @@ public class KafkaCollectorTest {
         assertEquals(0, metrics.size());
     }
 
+    @Test
+    public void testHelpMessageForMetric() {
+        KafkaCollector collector = new KafkaCollector();
+        AbstractReporter reporter = new AbstractReporter() {
+            @Override
+            protected Pattern allowlist() {
+                return Pattern.compile(".*");
+            }
+        };
+        collector.addReporter(reporter);
+
+        // Adding a numeric metric
+        AtomicInteger value = new AtomicInteger(1);
+        MetricName metricName = new MetricName("testMetric", "testGroup", "description", tagsMap);
+        MetricWrapper metricWrapper = newKafkaMetricWrapper(metricName, (config, now) -> value.get());
+        reporter.addMetric(metricName, metricWrapper);
+
+        List<? extends MetricSnapshot> metrics = collector.collect();
+        assertEquals(1, metrics.size());
+        MetricSnapshot snapshot = metrics.get(0);
+
+        String expectedHelpMessage = "Use kafka_server_testgroup_testmetric in allowlist";
+        assertEquals(expectedHelpMessage, snapshot.getMetadata().getHelp());
+    }
+
+    @Test
+    public void testHelpMessageForNonNumericMetric() {
+        KafkaCollector collector = new KafkaCollector();
+        AbstractReporter reporter = new AbstractReporter() {
+            @Override
+            protected Pattern allowlist() {
+                return Pattern.compile(".*");
+            }
+        };
+        collector.addReporter(reporter);
+
+        // Adding a non-numeric metric
+        String nonNumericValue = "testValue";
+        MetricName metricName = new MetricName("stringMetric", "testGroup", "description", tagsMap);
+        MetricWrapper metricWrapper = newKafkaMetricWrapper(metricName, (config, now) -> nonNumericValue);
+        reporter.addMetric(metricName, metricWrapper);
+
+        List<? extends MetricSnapshot> metrics = collector.collect();
+        assertEquals(1, metrics.size());
+        MetricSnapshot snapshot = metrics.get(0);
+
+        // Verify help message contains the JMX attribute
+        String expectedHelpMessage = "Use kafka_server_testgroup_stringmetric in allowlist";
+        assertEquals(expectedHelpMessage, snapshot.getMetadata().getHelp());
+    }
+
     private MetricWrapper newKafkaMetricWrapper(MetricName metricName, Gauge<?> gauge) {
         KafkaMetric kafkaMetric = newKafkaMetric(metricName.name(), metricName.group(), gauge, metricName.tags());
         String prometheusName = KafkaMetricWrapper.prometheusName(METRIC_PREFIX, metricName);

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollectorTest.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollectorTest.java
@@ -127,7 +127,7 @@ public class KafkaCollectorTest {
 
         // Test numeric metric
         MetricName numericMetricName = new MetricName("testMetric", "testGroup", "description", tagsMap);
-        MetricWrapper metricWrapper = newKafkaMetricWrapper(numericMetricName, (config, now) -> new AtomicInteger(1).get());
+        MetricWrapper metricWrapper = newKafkaMetricWrapper(numericMetricName, (config, now) -> 1);
         reporter.addMetric(numericMetricName, metricWrapper);
 
         List<? extends MetricSnapshot> metrics = collector.collect();

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollectorTest.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaCollectorTest.java
@@ -115,7 +115,7 @@ public class KafkaCollectorTest {
     }
 
     @Test
-    public void testHelpMessageForMetric() {
+    public void testHelpMessage() {
         KafkaCollector collector = new KafkaCollector();
         AbstractReporter reporter = new AbstractReporter() {
             @Override
@@ -125,44 +125,33 @@ public class KafkaCollectorTest {
         };
         collector.addReporter(reporter);
 
-        // Adding a numeric metric
+        // Test numeric metric
         AtomicInteger value = new AtomicInteger(1);
-        MetricName metricName = new MetricName("testMetric", "testGroup", "description", tagsMap);
-        MetricWrapper metricWrapper = newKafkaMetricWrapper(metricName, (config, now) -> value.get());
-        reporter.addMetric(metricName, metricWrapper);
+        MetricName numericMetricName = new MetricName("testMetric", "testGroup", "description", tagsMap);
+        MetricWrapper metricWrapper = newKafkaMetricWrapper(numericMetricName, (config, now) -> value.get());
+        reporter.addMetric(numericMetricName, metricWrapper);
 
         List<? extends MetricSnapshot> metrics = collector.collect();
         assertEquals(1, metrics.size());
         MetricSnapshot snapshot = metrics.get(0);
 
-        String expectedHelpMessage = "Use kafka_server_testgroup_testmetric in allowlist";
+        String expectedHelpMessage = "Use " + metricWrapper.prometheusName() + " in allowlist";
         assertEquals(expectedHelpMessage, snapshot.getMetadata().getHelp());
-    }
 
-    @Test
-    public void testHelpMessageForNonNumericMetric() {
-        KafkaCollector collector = new KafkaCollector();
-        AbstractReporter reporter = new AbstractReporter() {
-            @Override
-            protected Pattern allowlist() {
-                return Pattern.compile(".*");
-            }
-        };
-        collector.addReporter(reporter);
+        reporter.removeMetric(numericMetricName);
 
-        // Adding a non-numeric metric
+        // Test non-numeric metric
         String nonNumericValue = "testValue";
-        MetricName metricName = new MetricName("stringMetric", "testGroup", "description", tagsMap);
-        MetricWrapper metricWrapper = newKafkaMetricWrapper(metricName, (config, now) -> nonNumericValue);
-        reporter.addMetric(metricName, metricWrapper);
+        MetricName stringMetricName = new MetricName("stringMetric", "testGroup", "description", tagsMap);
+        MetricWrapper stringMetricWrapper = newKafkaMetricWrapper(stringMetricName, (config, now) -> nonNumericValue);
+        reporter.addMetric(stringMetricName, stringMetricWrapper);
 
-        List<? extends MetricSnapshot> metrics = collector.collect();
+        metrics = collector.collect();
         assertEquals(1, metrics.size());
-        MetricSnapshot snapshot = metrics.get(0);
+        MetricSnapshot stringSnapshot = metrics.get(0);
 
-        // Verify help message contains the JMX attribute
-        String expectedHelpMessage = "Use kafka_server_testgroup_stringmetric in allowlist";
-        assertEquals(expectedHelpMessage, snapshot.getMetadata().getHelp());
+        expectedHelpMessage = "Use " + stringMetricWrapper.prometheusName() + " in allowlist";
+        assertEquals(expectedHelpMessage, stringSnapshot.getMetadata().getHelp());
     }
 
     private MetricWrapper newKafkaMetricWrapper(MetricName metricName, Gauge<?> gauge) {

--- a/server-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollector.java
+++ b/server-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollector.java
@@ -93,7 +93,7 @@ public class YammerCollector implements MetricsCollector {
                 Object metric = metricWrapper.metric();
                 Labels labels = metricWrapper.labels();
                 LOG.debug("Collecting Yammer metric {} with the following labels: {}", prometheusMetricName, labels);
-                String helpMessage = String.format("Use '" + prometheusMetricName + "' in allowlist");
+                String helpMessage = "Use " + prometheusMetricName + " in allowlist";
                 if (metric instanceof Counter) {
                     Counter counter = (Counter) metric;
                     CounterSnapshot.Builder builder = (CounterSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> CounterSnapshot.builder().name(prometheusMetricName).help(helpMessage));

--- a/server-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollector.java
+++ b/server-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollector.java
@@ -93,32 +93,32 @@ public class YammerCollector implements MetricsCollector {
                 Object metric = metricWrapper.metric();
                 Labels labels = metricWrapper.labels();
                 LOG.debug("Collecting Yammer metric {} with the following labels: {}", prometheusMetricName, labels);
-
+                String helpMessage = String.format("Use '" + prometheusMetricName + "' in allowlist");
                 if (metric instanceof Counter) {
                     Counter counter = (Counter) metric;
-                    CounterSnapshot.Builder builder = (CounterSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> CounterSnapshot.builder().name(prometheusMetricName));
+                    CounterSnapshot.Builder builder = (CounterSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> CounterSnapshot.builder().name(prometheusMetricName).help(helpMessage));
                     builder.dataPoint(DataPointSnapshotBuilder.counterDataPoint(labels, counter.count()));
                 } else if (metric instanceof Gauge) {
                     Object valueObj = ((Gauge<?>) metric).value();
                     if (valueObj instanceof Number) {
                         double value = ((Number) valueObj).doubleValue();
-                        GaugeSnapshot.Builder builder = (GaugeSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> GaugeSnapshot.builder().name(prometheusMetricName));
+                        GaugeSnapshot.Builder builder = (GaugeSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> GaugeSnapshot.builder().name(prometheusMetricName).help(helpMessage));
                         builder.dataPoint(DataPointSnapshotBuilder.gaugeDataPoint(labels, value));
                     } else {
-                        InfoSnapshot.Builder builder = (InfoSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> InfoSnapshot.builder().name(prometheusMetricName));
+                        InfoSnapshot.Builder builder = (InfoSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> InfoSnapshot.builder().name(prometheusMetricName).help(helpMessage));
                         builder.dataPoint(DataPointSnapshotBuilder.infoDataPoint(labels, valueObj, metricWrapper.attribute()));
                     }
                 } else if (metric instanceof Timer) {
                     Timer timer = (Timer) metric;
-                    SummarySnapshot.Builder builder = (SummarySnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> SummarySnapshot.builder().name(prometheusMetricName));
+                    SummarySnapshot.Builder builder = (SummarySnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> SummarySnapshot.builder().name(prometheusMetricName).help(helpMessage));
                     builder.dataPoint(DataPointSnapshotBuilder.summaryDataPoint(labels, timer.count(), timer.sum(), quantiles(timer)));
                 } else if (metric instanceof Histogram) {
                     Histogram histogram = (Histogram) metric;
-                    SummarySnapshot.Builder builder = (SummarySnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> SummarySnapshot.builder().name(prometheusMetricName));
+                    SummarySnapshot.Builder builder = (SummarySnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> SummarySnapshot.builder().name(prometheusMetricName).help(helpMessage));
                     builder.dataPoint(DataPointSnapshotBuilder.summaryDataPoint(labels, histogram.count(), histogram.sum(), quantiles(histogram)));
                 } else if (metric instanceof Meter) {
                     Meter meter = (Meter) metric;
-                    CounterSnapshot.Builder builder = (CounterSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> CounterSnapshot.builder().name(prometheusMetricName));
+                    CounterSnapshot.Builder builder = (CounterSnapshot.Builder) builders.computeIfAbsent(prometheusMetricName, k -> CounterSnapshot.builder().name(prometheusMetricName).help(helpMessage));
                     builder.dataPoint(DataPointSnapshotBuilder.counterDataPoint(labels, meter.count()));
                 } else {
                     LOG.error("The metric {} has an unexpected type: {}", prometheusMetricName, metric.getClass().getName());

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerKafkaMetricsReporterTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerKafkaMetricsReporterTest.java
@@ -73,4 +73,28 @@ public class ServerKafkaMetricsReporterTest extends ClientMetricsReporterTest {
             assertThrows(ConfigException.class, () -> reporter.validateReconfiguration(configs));
         }
     }
+
+    @Test
+    public void testHelpMessageInOutput() throws Exception {
+        ServerKafkaMetricsReporter reporter = new ServerKafkaMetricsReporter(registry, kafkaCollector);
+        configs.put(ServerMetricsReporterConfig.ALLOWLIST_CONFIG, "kafka_server_group_name.*");
+        reporter.configure(configs);
+        reporter.contextChange(new KafkaMetricsContext("kafka.server"));
+
+        int port = reporter.getPort().orElseThrow();
+
+        // Add a metric that matches the allowlist
+        KafkaMetric metric = newKafkaMetric("name", "group", (config, now) -> 0, LABELS);
+        reporter.metricChange(metric);
+
+        // Get metrics output including comments
+        List<String> metrics = getMetrics(port, true);
+
+        // Verify that the output contains the "Use prometheusMetricName in allowlist" help line
+        boolean foundHelpLine = metrics.stream()
+                .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use kafka_server_group_name") && line.contains("in allowlist"));
+        assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use prometheusMetricName in allowlist' message");
+
+        reporter.close();
+    }
 }

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerKafkaMetricsReporterTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerKafkaMetricsReporterTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.kafka.metrics.prometheus;
 
+import io.strimzi.kafka.metrics.prometheus.kafka.KafkaMetricWrapper;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
@@ -90,10 +91,12 @@ public class ServerKafkaMetricsReporterTest extends ClientMetricsReporterTest {
         // Get metrics output including comments
         List<String> metrics = getMetrics(port, true);
 
+        String expectedPrometheusName = KafkaMetricWrapper.prometheusName("kafka.server", metric.metricName());
+
         // Verify that the output contains the "Use prometheusMetricName in allowlist" help line
         boolean foundHelpLine = metrics.stream()
-                .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use kafka_server_group_name") && line.contains("in allowlist"));
-        assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use prometheusMetricName in allowlist' message");
+                .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use " + expectedPrometheusName) && line.contains("in allowlist"));
+        assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use " + expectedPrometheusName + "in allowlist' message");
 
         reporter.close();
     }

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerKafkaMetricsReporterTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerKafkaMetricsReporterTest.java
@@ -95,7 +95,7 @@ public class ServerKafkaMetricsReporterTest extends ClientMetricsReporterTest {
 
         // Verify that the output contains the "Use prometheusMetricName in allowlist" help line
         boolean foundHelpLine = metrics.stream()
-                .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use " + expectedPrometheusName) && line.contains("in allowlist"));
+                .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use " + expectedPrometheusName + " in allowlist"));
         assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use " + expectedPrometheusName + "in allowlist' message");
 
         reporter.close();

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerYammerMetricsReporterTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerYammerMetricsReporterTest.java
@@ -12,6 +12,7 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.strimzi.kafka.metrics.prometheus.common.PrometheusCollector;
 import io.strimzi.kafka.metrics.prometheus.http.HttpServers;
 import io.strimzi.kafka.metrics.prometheus.yammer.YammerCollector;
+import io.strimzi.kafka.metrics.prometheus.yammer.YammerMetricWrapper;
 import kafka.utils.VerifiableProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -121,16 +122,20 @@ public class ServerYammerMetricsReporterTest {
             httpServer = reporter.config.startHttpServer().orElseThrow();
             int port = httpServer.port();
 
+            MetricName metricName = new MetricName("group", "type", "name", "");
+
             // Add a metric that matches the allowlist
             newCounter("group", "type", "name");
 
             // Get metrics output including comments
             List<String> metrics = getMetrics(port, true);
 
+            String expectedPrometheusName = YammerMetricWrapper.prometheusName(metricName);
+
             // Verify that the output contains the "Use prometheusMetricName in allowlist" help line
             boolean foundHelpLine = metrics.stream()
-                    .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use group_type_name") && line.contains("in allowlist"));
-            assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use prometheusMetricName in allowlist' message");
+                    .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use " + YammerMetricWrapper.prometheusName(metricName)) && line.contains("in allowlist"));
+            assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use " + expectedPrometheusName + " in allowlist' message");
         } finally {
             if (httpServer != null) HttpServers.release(httpServer);
         }

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerYammerMetricsReporterTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerYammerMetricsReporterTest.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 
 import static io.strimzi.kafka.metrics.prometheus.MetricsUtils.getMetrics;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ServerYammerMetricsReporterTest {
 
@@ -107,5 +108,31 @@ public class ServerYammerMetricsReporterTest {
     private void removeMetric(String group, String type, String name) {
         MetricName metricName = new MetricName(group, type, name, "");
         Metrics.defaultRegistry().removeMetric(metricName);
+    }
+
+    @Test
+    public void testHelpMessageInOutput() throws Exception {
+        ServerYammerMetricsReporter reporter = new ServerYammerMetricsReporter(registry, yammerCollector);
+        configs.put(ServerMetricsReporterConfig.ALLOWLIST_CONFIG, "group_type.*");
+        reporter.init(new VerifiableProperties(configs));
+
+        HttpServers.ServerCounter httpServer = null;
+        try {
+            httpServer = reporter.config.startHttpServer().orElseThrow();
+            int port = httpServer.port();
+
+            // Add a metric that matches the allowlist
+            newCounter("group", "type", "name");
+
+            // Get metrics output including comments
+            List<String> metrics = getMetrics(port, true);
+
+            // Verify that the output contains the "Use prometheusMetricName in allowlist" help line
+            boolean foundHelpLine = metrics.stream()
+                    .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use group_type_name") && line.contains("in allowlist"));
+            assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use prometheusMetricName in allowlist' message");
+        } finally {
+            if (httpServer != null) HttpServers.release(httpServer);
+        }
     }
 }

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerYammerMetricsReporterTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/ServerYammerMetricsReporterTest.java
@@ -134,7 +134,7 @@ public class ServerYammerMetricsReporterTest {
 
             // Verify that the output contains the "Use prometheusMetricName in allowlist" help line
             boolean foundHelpLine = metrics.stream()
-                    .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use " + YammerMetricWrapper.prometheusName(metricName)) && line.contains("in allowlist"));
+                    .anyMatch(line -> line.startsWith("# HELP") && line.contains("Use " + YammerMetricWrapper.prometheusName(metricName) + " in allowlist"));
             assertTrue(foundHelpLine, "Expected to find '# HELP' line with 'Use " + expectedPrometheusName + " in allowlist' message");
         } finally {
             if (httpServer != null) HttpServers.release(httpServer);

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollectorTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollectorTest.java
@@ -102,6 +102,53 @@ public class YammerCollectorTest {
         assertInfoSnapshot(snapshot, labels, "name", nonNumericValue);
     }
 
+    @Test
+    public void testHelpMessageForMetric() {
+        AbstractReporter reporter = new AbstractReporter() {
+            @Override
+            protected Pattern allowlist() {
+                return Pattern.compile(".*");
+            }
+        };
+        collector.addReporter(reporter);
+
+        AtomicInteger value = new AtomicInteger(1);
+        MetricName metricName = new MetricName("group", "type", "testMetric", scope);
+        MetricWrapper metricWrapper = newYammerMetricWrapper(metricName, value::get);
+        reporter.addMetric(metricName, metricWrapper);
+
+        List<? extends MetricSnapshot> metrics = collector.collect();
+        assertEquals(1, metrics.size());
+        MetricSnapshot snapshot = metrics.get(0);
+
+        String expectedHelpMessage = "Use " + metricWrapper.prometheusName() + " in allowlist";
+        assertEquals(expectedHelpMessage, snapshot.getMetadata().getHelp());
+    }
+
+    @Test
+    public void testHelpMessageForNonNumericMetric() {
+        AbstractReporter reporter = new AbstractReporter() {
+            @Override
+            protected Pattern allowlist() {
+                return Pattern.compile(".*");
+            }
+        };
+        collector.addReporter(reporter);
+
+        String stringValue = "testValue";
+        MetricName metricName = new MetricName("group", "type", "stringMetric", scope);
+        MetricWrapper metricWrapper = newYammerMetricWrapper(metricName, () -> stringValue);
+        reporter.addMetric(metricName, metricWrapper);
+
+        List<? extends MetricSnapshot> metrics = collector.collect();
+        assertEquals(1, metrics.size());
+        MetricSnapshot snapshot = metrics.get(0);
+
+        // Verify help message follows the allowlist pattern
+        String expectedHelpMessage = "Use " + metricWrapper.prometheusName() + " in allowlist";
+        assertEquals(expectedHelpMessage, snapshot.getMetadata().getHelp());
+    }
+
     private <T> MetricWrapper newYammerMetricWrapper(MetricName metricName, Supplier<T> valueSupplier) {
         Gauge<T> gauge = newYammerMetric(valueSupplier);
         String prometheusName = YammerMetricWrapper.prometheusName(metricName);

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollectorTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollectorTest.java
@@ -103,7 +103,7 @@ public class YammerCollectorTest {
     }
 
     @Test
-    public void testHelpMessageForMetric() {
+    public void testHelpMessage() {
         AbstractReporter reporter = new AbstractReporter() {
             @Override
             protected Pattern allowlist() {
@@ -112,41 +112,33 @@ public class YammerCollectorTest {
         };
         collector.addReporter(reporter);
 
+        // Test numeric metric
         AtomicInteger value = new AtomicInteger(1);
-        MetricName metricName = new MetricName("group", "type", "testMetric", scope);
-        MetricWrapper metricWrapper = newYammerMetricWrapper(metricName, value::get);
-        reporter.addMetric(metricName, metricWrapper);
+        MetricName numericMetricName = new MetricName("group", "type", "testMetric", scope);
+        MetricWrapper numericMetricWrapper = newYammerMetricWrapper(numericMetricName, value::get);
+        reporter.addMetric(numericMetricName, numericMetricWrapper);
 
         List<? extends MetricSnapshot> metrics = collector.collect();
         assertEquals(1, metrics.size());
-        MetricSnapshot snapshot = metrics.get(0);
+        MetricSnapshot numericSnapshot = metrics.get(0);
 
-        String expectedHelpMessage = "Use " + metricWrapper.prometheusName() + " in allowlist";
-        assertEquals(expectedHelpMessage, snapshot.getMetadata().getHelp());
-    }
+        String expectedHelpMessage = "Use " + numericMetricWrapper.prometheusName() + " in allowlist";
+        assertEquals(expectedHelpMessage, numericSnapshot.getMetadata().getHelp());
 
-    @Test
-    public void testHelpMessageForNonNumericMetric() {
-        AbstractReporter reporter = new AbstractReporter() {
-            @Override
-            protected Pattern allowlist() {
-                return Pattern.compile(".*");
-            }
-        };
-        collector.addReporter(reporter);
+        reporter.removeMetric(numericMetricName);
 
+        // Test non-numeric metric
         String stringValue = "testValue";
-        MetricName metricName = new MetricName("group", "type", "stringMetric", scope);
-        MetricWrapper metricWrapper = newYammerMetricWrapper(metricName, () -> stringValue);
-        reporter.addMetric(metricName, metricWrapper);
+        MetricName stringMetricName = new MetricName("group", "type", "stringMetric", scope);
+        MetricWrapper stringMetricWrapper = newYammerMetricWrapper(stringMetricName, () -> stringValue);
+        reporter.addMetric(stringMetricName, stringMetricWrapper);
 
-        List<? extends MetricSnapshot> metrics = collector.collect();
+        metrics = collector.collect();
         assertEquals(1, metrics.size());
-        MetricSnapshot snapshot = metrics.get(0);
+        MetricSnapshot stringSnapshot = metrics.get(0);
 
-        // Verify help message follows the allowlist pattern
-        String expectedHelpMessage = "Use " + metricWrapper.prometheusName() + " in allowlist";
-        assertEquals(expectedHelpMessage, snapshot.getMetadata().getHelp());
+        expectedHelpMessage = "Use " + stringMetricWrapper.prometheusName() + " in allowlist";
+        assertEquals(expectedHelpMessage, stringSnapshot.getMetadata().getHelp());
     }
 
     private <T> MetricWrapper newYammerMetricWrapper(MetricName metricName, Supplier<T> valueSupplier) {

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollectorTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollectorTest.java
@@ -114,7 +114,7 @@ public class YammerCollectorTest {
 
         // Test numeric metric
         MetricName numericMetricName = new MetricName("group", "type", "testMetric", scope);
-        MetricWrapper numericMetricWrapper = newYammerMetricWrapper(numericMetricName, new AtomicInteger(1)::get);
+        MetricWrapper numericMetricWrapper = newYammerMetricWrapper(numericMetricName, () -> 1);
         reporter.addMetric(numericMetricName, numericMetricWrapper);
 
         List<? extends MetricSnapshot> metrics = collector.collect();

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollectorTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerCollectorTest.java
@@ -113,32 +113,28 @@ public class YammerCollectorTest {
         collector.addReporter(reporter);
 
         // Test numeric metric
-        AtomicInteger value = new AtomicInteger(1);
         MetricName numericMetricName = new MetricName("group", "type", "testMetric", scope);
-        MetricWrapper numericMetricWrapper = newYammerMetricWrapper(numericMetricName, value::get);
+        MetricWrapper numericMetricWrapper = newYammerMetricWrapper(numericMetricName, new AtomicInteger(1)::get);
         reporter.addMetric(numericMetricName, numericMetricWrapper);
 
         List<? extends MetricSnapshot> metrics = collector.collect();
         assertEquals(1, metrics.size());
-        MetricSnapshot numericSnapshot = metrics.get(0);
 
         String expectedHelpMessage = "Use " + numericMetricWrapper.prometheusName() + " in allowlist";
-        assertEquals(expectedHelpMessage, numericSnapshot.getMetadata().getHelp());
+        assertEquals(expectedHelpMessage, metrics.get(0).getMetadata().getHelp());
 
         reporter.removeMetric(numericMetricName);
 
         // Test non-numeric metric
-        String stringValue = "testValue";
         MetricName stringMetricName = new MetricName("group", "type", "stringMetric", scope);
-        MetricWrapper stringMetricWrapper = newYammerMetricWrapper(stringMetricName, () -> stringValue);
+        MetricWrapper stringMetricWrapper = newYammerMetricWrapper(stringMetricName, () -> "testValue");
         reporter.addMetric(stringMetricName, stringMetricWrapper);
 
         metrics = collector.collect();
         assertEquals(1, metrics.size());
-        MetricSnapshot stringSnapshot = metrics.get(0);
 
         expectedHelpMessage = "Use " + stringMetricWrapper.prometheusName() + " in allowlist";
-        assertEquals(expectedHelpMessage, stringSnapshot.getMetadata().getHelp());
+        assertEquals(expectedHelpMessage, metrics.get(0).getMetadata().getHelp());
     }
 
     private <T> MetricWrapper newYammerMetricWrapper(MetricName metricName, Supplier<T> valueSupplier) {


### PR DESCRIPTION
This PR is designed to fix https://github.com/strimzi/metrics-reporter/issues/105. 
A Help message is added to the metrics to document how a corresponding metric name is to be used in the Metric Reporter configuration in relation to the `allowList`.