### PR TITLE
Bump Prometheus to 1.7.0 and fix label deduplication for the new API

### DIFF
--- a/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/common/DataPointSnapshotBuilder.java
+++ b/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/common/DataPointSnapshotBuilder.java
@@ -33,7 +33,7 @@ public class DataPointSnapshotBuilder {
      * @return The {@link InfoSnapshot.InfoDataPointSnapshot} datapoint
      */
     public static InfoSnapshot.InfoDataPointSnapshot infoDataPoint(Labels labels, Object value, String metricName) {
-        String newLabelName = PrometheusNaming.sanitizeLabelName(metricName);
+        String newLabelName = PrometheusNaming.prometheusName(PrometheusNaming.sanitizeLabelName(metricName));
         Labels newLabels = labels;
         String existingValue = labels.get(newLabelName);
         if (existingValue != null) {

--- a/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaMetricWrapper.java
+++ b/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaMetricWrapper.java
@@ -50,7 +50,7 @@ public class KafkaMetricWrapper extends MetricWrapper {
         Labels.Builder builder = Labels.builder();
         Set<String> labelNames = new HashSet<>();
         for (Map.Entry<String, String> label : tags.entrySet()) {
-            String newLabelName = PrometheusNaming.sanitizeLabelName(label.getKey());
+            String newLabelName = PrometheusNaming.prometheusName(PrometheusNaming.sanitizeLabelName(label.getKey()));
             if (labelNames.add(newLabelName)) {
                 builder.label(newLabelName, label.getValue());
             } else {

--- a/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaMetricWrapperTest.java
+++ b/client-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/kafka/KafkaMetricWrapperTest.java
@@ -47,7 +47,7 @@ public class KafkaMetricWrapperTest {
         tags.put("k-1", "v1");
         tags.put("k_1", "v2");
         labels = KafkaMetricWrapper.labelsFromTags(tags, "");
-        assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
+        assertEquals("k_1", PrometheusNaming.prometheusName(PrometheusNaming.sanitizeLabelName("k-1")));
         assertEquals("v1", labels.get("k_1"));
         assertEquals(1, labels.size());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
 
     <kafka.version>4.2.0</kafka.version>
-    <prometheus.version>1.3.6</prometheus.version>
+    <prometheus.version>1.7.0</prometheus.version>
     <yammer.version>2.2.0</yammer.version>
     <slf4j.version>2.0.17</slf4j.version>
     <log4j.version>2.25.4</log4j.version>

--- a/server-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerMetricWrapper.java
+++ b/server-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerMetricWrapper.java
@@ -72,7 +72,7 @@ public class YammerMetricWrapper extends MetricWrapper {
                 String value = property.substring(eqIdx + 1);
                 // Example labels: {topic="env.topicname.version"} - type and name properties are ignored as not in scope
                 if (!labelKeys.contains(key)) continue;
-                String labelName = PrometheusNaming.sanitizeLabelName(key);
+                String labelName = PrometheusNaming.prometheusName(PrometheusNaming.sanitizeLabelName(key));
                 if (labelNames.add(labelName)) {
                     builder.label(labelName, value);
                 } else {

--- a/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerMetricWrapperTest.java
+++ b/server-metrics-reporter/src/test/java/io/strimzi/kafka/metrics/prometheus/yammer/YammerMetricWrapperTest.java
@@ -24,7 +24,7 @@ public class YammerMetricWrapperTest {
         assertEquals(Labels.EMPTY, YammerMetricWrapper.labelsFromScopeAndMBeanName("", "group:type=T,name=N,k1=v1", "name"));
         assertEquals(Labels.EMPTY, YammerMetricWrapper.labelsFromScopeAndMBeanName("k1.v1", null, "name"));
         Labels labels = YammerMetricWrapper.labelsFromScopeAndMBeanName("k-1.v1.k_1.v2", "group:k-1=v1,k_1=v2", "name");
-        assertEquals("k_1", PrometheusNaming.sanitizeLabelName("k-1"));
+        assertEquals("k_1", PrometheusNaming.prometheusName(PrometheusNaming.sanitizeLabelName("k-1")));
         assertEquals("v1", labels.get("k_1"));
         assertEquals(1, labels.size());
         // Dots in topic names are preserved: scope determines which keys are labels, MBean name provides the original (unsanitized) values


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR bumps the Prometheus Java client to 1.7.0 to align with latest update on the Strimzi operator and HTTP bridge. A plain version bump is not enough because this release changed the contract of `PrometheusNaming.sanitizeLabelName()`: it no longer replaces illegal characters such as hyphens with underscores. Such a normalisation was moved into `prometheusName()`, which is now called internally by Labels.of() before validation.

Our duplicate-label guard in `KafkaMetricWrapper`, `YammerMetricWrapper`, and `DataPointSnapshotBuilder` was using `sanitizeLabelName()` as the dedup key. When a metric carries two tag keys that differ only by a hyphen vs. underscore (e.g. k-1 and k_1), the old method mapped both to k_1 so the HashSet caught the collision. With 1.7.0 it returns k-1 unchanged, both keys pass the guard, and Labels.of() then throws IllegalArgumentException: k_1: duplicate label name when it detects the collision itself.

The fix is is using `prometheusName(sanitizeLabelName(key))` instead, which mirrors what the library now does internally and restores correct dedup behaviour.

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
