### PR TITLE
Added AI assistants to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ hs_err_pid*
 
 .DS_Store
 
+# AI assistants configuration
+.claude/
+.mcp.json
+.bob/


### PR DESCRIPTION
### Type of change

- Task

### Description

As all the other Strimzi repositories, this PR adds the AI assistants more relevant folders to the gitignore.