### PR TITLE
Fixed Javadoc warning

### DIFF
--- a/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/http/Listener.java
+++ b/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/http/Listener.java
@@ -75,6 +75,11 @@ public class Listener {
      */
     public static class ListenerValidator implements ConfigDef.Validator {
 
+        /**
+         * Default constructor
+         */
+        public ListenerValidator() {}
+
         @Override
         public void ensureValid(String name, Object value) {
             parseListener(String.valueOf(value));


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds a public constructor to the `ListenerValidator` to fix a warning which drives the build failing when using Java 21 which enforces it. 

```shell
[WARNING] Javadoc Warnings
[WARNING] /home/ppatiern/github/metrics-reporter/client-metrics-reporter/src/main/java/io/strimzi/kafka/metrics/prometheus/http/Listener.java:76: warning: use of default constructor, which does not provide a comment
[WARNING] public static class ListenerValidator implements ConfigDef.Validator {
[WARNING] ^
[WARNING] 1 warning
```

The same was done across all the other Strimzi repositories (i.e. operator, HTTP bridge, ...).

### Checklist

- [x] Make sure all tests pass